### PR TITLE
Remove time window for prefect_flow_runs_total and prefect_flow_runs_total_run_time

### DIFF
--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -64,3 +64,31 @@ class PrefectFlowRuns:
                 break
 
         return resp.json()
+
+    def get_all_flow_runs_info(self) -> dict:
+        """
+        Get information about all flow runs.
+
+        Returns:
+            dict: JSON response containing flow runs information.
+        """
+        endpoint = f"{self.url}/{self.uri}/filter"
+        data = {
+            "flow_runs": {
+                "operator": "and_",
+            }
+        }
+
+        for retry in range(self.max_retries):
+            try:
+                resp = requests.post(endpoint, headers=self.headers, json=data)
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as err:
+                self.logger.error(err)
+                if retry >= self.max_retries - 1:
+                    time.sleep(1)
+                    raise SystemExit(err)
+            else:
+                break
+
+        return resp.json()

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -3,7 +3,7 @@ from metrics.flow_runs import PrefectFlowRuns
 from metrics.flows import PrefectFlows
 from metrics.work_pools import PrefectWorkPools
 from metrics.work_queues import PrefectWorkQueues
-from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
 
 
 class PrefectMetrics(object):
@@ -41,6 +41,7 @@ class PrefectMetrics(object):
         deployments = PrefectDeployments(self.url, self.headers, self.max_retries, self.logger).get_deployments_info()
         flows = PrefectFlows(self.url, self.headers, self.max_retries, self.logger).get_flows_info()
         flow_runs = PrefectFlowRuns(self.url, self.headers, self.max_retries, self.offset_minutes, self.logger).get_flow_runs_info()
+        all_flow_runs = PrefectFlowRuns(self.url, self.headers, self.max_retries, self.offset_minutes, self.logger).get_all_flow_runs_info()
         work_pools = PrefectWorkPools(self.url, self.headers, self.max_retries, self.logger).get_work_pools_info()
         work_queues = PrefectWorkQueues(self.url, self.headers, self.max_retries, self.logger).get_work_queues_info()
 
@@ -114,17 +115,17 @@ class PrefectMetrics(object):
         #
 
         # prefect_flow_runs metric
-        prefect_flow_runs = GaugeMetricFamily("prefect_flow_runs_total", "Prefect total flow runs", labels=[])
-        prefect_flow_runs.add_metric([], len(flow_runs))
+        prefect_flow_runs = CounterMetricFamily("prefect_flow_runs_total", "Prefect total flow runs", labels=[])
+        prefect_flow_runs.add_metric([], len(all_flow_runs))
         yield prefect_flow_runs
 
         # prefect_flow_runs_total_run_time metric
-        prefect_flow_runs_total_run_time = GaugeMetricFamily("prefect_flow_runs_total_run_time", "Prefect flow-run total run time in seconds", labels=[
+        prefect_flow_runs_total_run_time = CounterMetricFamily("prefect_flow_runs_total_run_time", "Prefect flow-run total run time in seconds", labels=[
                                           "flow_id", "flow_name", "flow_run_name"
                                         ]
                                       )
 
-        for flow_run in flow_runs:
+        for flow_run in all_flow_runs:
             # get deployment name
             if flow_run.get("deployment_id") is None:
                 deployment_name = "null"


### PR DESCRIPTION
Just going off the names, these metrics seem more suited to being counters. Existing behavior is possible to get in Grafana using for example `sum(rate(prefect_flow_runs_total[$__range]))`.