### PR TITLE
chore/Trigger release of prometheus exporter automatically

### DIFF
--- a/.github/workflows/release-build-deploy.yaml
+++ b/.github/workflows/release-build-deploy.yaml
@@ -53,3 +53,11 @@ jobs:
           push: true
           pull: true
           provenance: false
+
+      - name: Trigger Downstream Helm Chart Upgrade
+        run: |
+          gh workflow run prometheus-exporter-helm-release.yaml \
+              --repo=prefecthq/prefect-helm \
+              --ref=main 
+        env: 
+          GITHUB_TOKEN: ${{ secrets.PREFECT_HELM_ACTIONS_RW }}

--- a/.github/workflows/release-build-deploy.yaml
+++ b/.github/workflows/release-build-deploy.yaml
@@ -58,6 +58,6 @@ jobs:
         run: |
           gh workflow run prometheus-exporter-helm-release.yaml \
               --repo=prefecthq/prefect-helm \
-              --ref=main 
+              --ref=main
         env: 
           GITHUB_TOKEN: ${{ secrets.PREFECT_HELM_ACTIONS_RW }}


### PR DESCRIPTION
- Relates: https://github.com/PrefectHQ/platform/issues/6860
- Adds the ability to trigger the release GHA for the helm chart when a release for the exporter occurs