### PR TITLE
chore: add Docker Compose for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ pip install -r requirements.txt
 python main.py
 ```
 
+#### Using Docker Compose
+
+Alternatively, you can use the [Docker Compose configuration](./compose.yml)
+to stand up the exporter alongside Prefect and Prometheus.
+
+To get started, run:
+
+```bash
+docker compose up -d
+```
+
+Confirm the services are running and healthy:
+
+```
+docker compose ps
+```
+
+You can now reach each service locally:
+
+- Prefect: http://localhost:4200
+- Exporter: http://localhost:8000
+- Prometheus: http://localhost:9090
+
 ## Configuration
 
 You can modify environment variables to change the behavior of the exporter.

--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,8 @@ services:
       - "0.0.0.0"
       - --port
       - "4200"
+    healthcheck:
+      test: ["CMD-SHELL", "prefect version"]
 
   prometheus-exporter:
     build:
@@ -21,6 +23,9 @@ services:
       - "8000:8000"
     environment:
       PREFECT_API_URL: http://prefect:4200/api
+    depends_on:
+      prefect:
+        condition: service_healthy
 
   prometheus:
     image: prom/prometheus:latest

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,32 @@
+services:
+  prefect:
+    image: prefecthq/prefect:2-latest
+    ports:
+      - "4200:4200"
+    environment:
+      PREFECT_LOGGING_LEVEL: debug
+    command:
+      - prefect
+      - server
+      - start
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "4200"
+
+  prometheus-exporter:
+    build:
+      dockerfile: ./Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      PREFECT_API_URL: http://prefect:4200/api
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+  external_labels:
+    monitor: my-monitor
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: ceph-exporter
+    static_configs:
+      - targets: ['prometheus-exporter:8000']


### PR DESCRIPTION
Adds a Docker Compose configuration to allow for easy local testing against a real instance of Prefect, along with Prometheus to browse the metrics.