### PR TITLE
Feat/Support Prefect API Pagination

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from metrics.metrics import PrefectMetrics
 from metrics.healthz import PrefectHealthz
 from prometheus_client import start_http_server, REGISTRY
 
+
 def metrics():
     """
     Main entry point for the PrefectMetrics exporter.
@@ -60,6 +61,7 @@ def metrics():
     # Run the loop to collect Prefect metrics
     while True:
         time.sleep(5)
+
 
 if __name__ == "__main__":
     metrics()

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 import requests
 
@@ -26,7 +27,7 @@ class PrefectApiMetric:
         self.max_retries = max_retries
         self.logger = logger
 
-    def _get_with_pagination(self):
+    def _get_with_pagination(self, base_data: Optional[dict] = None) -> dict:
         """
         Fetch all items from the endpoint with pagination.
 
@@ -41,11 +42,9 @@ class PrefectApiMetric:
         while True:
             for retry in range(self.max_retries):
                 data = {
+                    **(base_data or {}),
                     "limit": limit,
                     "offset": offset,
-                    "flow_runs": {
-                        "operator": "and_",
-                    },
                 }
 
                 try:

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -27,7 +27,7 @@ class PrefectApiMetric:
         self.max_retries = max_retries
         self.logger = logger
 
-    def _get_with_pagination(self, base_data: Optional[dict] = None) -> dict:
+    def _get_with_pagination(self, base_data: Optional[dict] = None) -> list:
         """
         Fetch all items from the endpoint with pagination.
 
@@ -39,6 +39,7 @@ class PrefectApiMetric:
         offset = 0
         all_items = []
 
+        # Run the loop until the current page is empty
         while True:
             for retry in range(self.max_retries):
                 data = {
@@ -58,12 +59,13 @@ class PrefectApiMetric:
                 else:
                     break
 
-            curr_page_flow_runs = resp.json()
+            curr_page_items = resp.json()
 
-            if not curr_page_flow_runs:
+            # If the current page is empty, break the loop
+            if not curr_page_items:
                 break
 
-            all_items.extend(curr_page_flow_runs)
+            all_items.extend(curr_page_items)
             offset += limit
 
         return all_items

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -1,0 +1,70 @@
+import time
+
+import requests
+
+
+class PrefectApiMetric:
+    """
+    PrefectDeployments class for interacting with Prefect's endpoints
+    """
+
+    def __init__(self, url, headers, max_retries, logger, uri) -> None:
+        """
+        Initialize the PrefectDeployments instance.
+
+        Args:
+            url (str): The URL of the Prefect instance.
+            headers (dict): Headers to be included in HTTP requests.
+            max_retries (int): The maximum number of retries for HTTP requests.
+            logger (obj): The logger object.
+            uri (str, optional): The URI path for the intended endpoint.
+
+        """
+        self.headers = headers
+        self.uri = uri
+        self.url = url
+        self.max_retries = max_retries
+        self.logger = logger
+
+    def _get_with_pagination(self):
+        """
+        Fetch all items from the endpoint with pagination.
+
+        Returns:
+            dict: JSON response containing all items from the endpoint.
+        """
+        endpoint = f"{self.url}/{self.uri}/filter"
+        limit = 200
+        offset = 0
+        all_items = []
+
+        while True:
+            for retry in range(self.max_retries):
+                data = {
+                    "limit": limit,
+                    "offset": offset,
+                    "flow_runs": {
+                        "operator": "and_",
+                    },
+                }
+
+                try:
+                    resp = requests.post(endpoint, headers=self.headers, json=data)
+                    resp.raise_for_status()
+                except requests.exceptions.HTTPError as err:
+                    self.logger.error(err)
+                    if retry >= self.max_retries - 1:
+                        time.sleep(1)
+                        raise SystemExit(err)
+                else:
+                    break
+
+            curr_page_flow_runs = resp.json()
+
+            if not curr_page_flow_runs:
+                break
+
+            all_items.extend(curr_page_flow_runs)
+            offset += limit
+
+        return all_items

--- a/metrics/deployments.py
+++ b/metrics/deployments.py
@@ -22,7 +22,7 @@ class PrefectDeployments(PrefectApiMetric):
             url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
         )
 
-    def get_deployments_info(self) -> dict:
+    def get_deployments_info(self) -> list:
         """
         Get information about Prefect deployments.
 

--- a/metrics/deployments.py
+++ b/metrics/deployments.py
@@ -1,8 +1,7 @@
-import requests
-import time
+from metrics.api_metric import PrefectApiMetric
 
 
-class PrefectDeployments:
+class PrefectDeployments(PrefectApiMetric):
     """
     PrefectDeployments class for interacting with Prefect's deployments endpoints.
     """
@@ -19,11 +18,9 @@ class PrefectDeployments:
             uri (str, optional): The URI path for deployments endpoints. Default is "deployments".
 
         """
-        self.headers = headers
-        self.uri = uri
-        self.url = url
-        self.max_retries = max_retries
-        self.logger = logger
+        super().__init__(
+            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+        )
 
     def get_deployments_info(self) -> dict:
         """
@@ -33,18 +30,6 @@ class PrefectDeployments:
             dict: JSON response containing information about deployments.
 
         """
-        endpoint = f"{self.url}/{self.uri}/filter"
+        all_deployments = self._get_with_pagination()
 
-        for retry in range(self.max_retries):
-            try:
-                resp = requests.post(endpoint, headers=self.headers)
-                resp.raise_for_status()
-            except requests.exceptions.HTTPError as err:
-                self.logger.error(err)
-                if retry >= self.max_retries - 1:
-                    time.sleep(1)
-                    raise SystemExit(err)
-            else:
-                break
-
-        return resp.json()
+        return all_deployments

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -31,7 +31,7 @@ class PrefectFlowRuns(PrefectApiMetric):
         after_data = datetime.now(timezone.utc) - timedelta(minutes=offset_minutes)
         self.after_data_fmt = after_data.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-    def get_flow_runs_info(self) -> dict:
+    def get_flow_runs_info(self) -> list:
         """
         Get information about flow runs within a specified time range.
 
@@ -50,7 +50,7 @@ class PrefectFlowRuns(PrefectApiMetric):
 
         return flow_runs
 
-    def get_all_flow_runs_info(self) -> dict:
+    def get_all_flow_runs_info(self) -> list:
         """
         Get information about all flow runs.
 

--- a/metrics/flows.py
+++ b/metrics/flows.py
@@ -1,8 +1,7 @@
-import requests
-import time
+from metrics.api_metric import PrefectApiMetric
 
 
-class PrefectFlows:
+class PrefectFlows(PrefectApiMetric):
     """
     PrefectFlows class for interacting with Prefect's flows endpoints.
     """
@@ -19,11 +18,9 @@ class PrefectFlows:
             uri (str, optional): The URI path for administrative endpoints. Default is "flows".
 
         """
-        self.headers = headers
-        self.uri = uri
-        self.url = url
-        self.max_retries = max_retries
-        self.logger = logger
+        super().__init__(
+            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+        )
 
     def get_flows_info(self) -> dict:
         """
@@ -33,18 +30,6 @@ class PrefectFlows:
             dict: JSON response containing information about flows.
 
         """
-        endpoint = f"{self.url}/{self.uri}/filter"
+        all_flows = self._get_with_pagination()
 
-        for retry in range(self.max_retries):
-            try:
-                resp = requests.post(endpoint, headers=self.headers)
-                resp.raise_for_status()
-            except requests.exceptions.HTTPError as err:
-                self.logger.error(err)
-                if retry >= self.max_retries - 1:
-                    time.sleep(1)
-                    raise SystemExit(err)
-            else:
-                break
-
-        return resp.json()
+        return all_flows

--- a/metrics/flows.py
+++ b/metrics/flows.py
@@ -22,7 +22,7 @@ class PrefectFlows(PrefectApiMetric):
             url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
         )
 
-    def get_flows_info(self) -> dict:
+    def get_flows_info(self) -> list:
         """
         Get information about Prefect flows.
 

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -15,7 +15,9 @@ class PrefectMetrics(object):
     PrefectMetrics class for collecting and exposing Prometheus metrics related to Prefect.
     """
 
-    def __init__(self, url, headers, offset_minutes, max_retries, csrf_enabled, client_id, logger) -> None:
+    def __init__(
+        self, url, headers, offset_minutes, max_retries, csrf_enabled, client_id, logger
+    ) -> None:
         """
         Initialize the PrefectMetrics instance.
 
@@ -47,7 +49,9 @@ class PrefectMetrics(object):
         #
         if self.csrf_enabled:
             if not self.csrf_token or pendulum.now("UTC") > self.csrf_token_expiration:
-                self.logger.info("CSRF Token is expired or has not been generated yet. Fetching new CSRF Token...")
+                self.logger.info(
+                    "CSRF Token is expired or has not been generated yet. Fetching new CSRF Token..."
+                )
                 token_information = self.get_csrf_token()
                 self.csrf_token = token_information.token
                 self.csrf_token_expiration = token_information.expiration
@@ -100,7 +104,7 @@ class PrefectMetrics(object):
                 "path",
                 "work_pool_name",
                 "work_queue_name",
-                "status"
+                "status",
             ],
         )
 
@@ -317,7 +321,7 @@ class PrefectMetrics(object):
                 "is_paused",
                 "work_pool_name",
                 "type",
-                "status"
+                "status",
             ],
         )
 
@@ -390,7 +394,11 @@ class PrefectMetrics(object):
                     str(status_info.get("late_runs_count", "null")),
                     str(status_info.get("last_polled", "null")),
                     str(health_check_policy.get("maximum_late_runs", "null")),
-                    str(health_check_policy.get("maximum_seconds_since_last_polled", "null")),
+                    str(
+                        health_check_policy.get(
+                            "maximum_seconds_since_last_polled", "null"
+                        )
+                    ),
                 ],
                 state,
             )
@@ -404,7 +412,9 @@ class PrefectMetrics(object):
         """
         for retry in range(self.max_retries):
             try:
-                csrf_token = requests.get(f"{self.url}/csrf-token?client={self.client_id}")
+                csrf_token = requests.get(
+                    f"{self.url}/csrf-token?client={self.client_id}"
+                )
             except requests.exceptions.HTTPError as err:
                 self.logger.error(err)
                 if retry >= self.max_retries - 1:

--- a/metrics/work_pools.py
+++ b/metrics/work_pools.py
@@ -1,8 +1,7 @@
-import requests
-import time
+from metrics.api_metric import PrefectApiMetric
 
 
-class PrefectWorkPools:
+class PrefectWorkPools(PrefectApiMetric):
     """
     PrefectWorkPools class for interacting with Prefect's work pools endpoints.
     """
@@ -19,11 +18,9 @@ class PrefectWorkPools:
             uri (str, optional): The URI path for administrative endpoints. Default is "work_pools".
 
         """
-        self.headers = headers
-        self.uri = uri
-        self.url = url
-        self.max_retries = max_retries
-        self.logger = logger
+        super().__init__(
+            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+        )
 
     def get_work_pools_info(self) -> dict:
         """
@@ -33,18 +30,6 @@ class PrefectWorkPools:
             dict: JSON response containing work pools information.
 
         """
-        endpoint = f"{self.url}/{self.uri}/filter"
+        all_work_pools = self._get_with_pagination()
 
-        for retry in range(self.max_retries):
-            try:
-                resp = requests.post(endpoint, headers=self.headers)
-                resp.raise_for_status()
-            except requests.exceptions.HTTPError as err:
-                self.logger.error(err)
-                if retry >= self.max_retries - 1:
-                    time.sleep(1)
-                    raise SystemExit(err)
-            else:
-                break
-
-        return resp.json()
+        return all_work_pools

--- a/metrics/work_pools.py
+++ b/metrics/work_pools.py
@@ -22,7 +22,7 @@ class PrefectWorkPools(PrefectApiMetric):
             url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
         )
 
-    def get_work_pools_info(self) -> dict:
+    def get_work_pools_info(self) -> list:
         """
         Get information about Prefect's work pools.
 

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -27,7 +27,7 @@ class PrefectWorkQueues(PrefectApiMetric):
             url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
         )
 
-    def get_work_queues_info(self) -> dict:
+    def get_work_queues_info(self) -> list:
         """
         Get information about Prefect's work queues.
 


### PR DESCRIPTION
Hey,

Thank you for this great project - it has great potential to help us monitor our OSS Prefect deployment.

This PR adds pagination support to the API based metrics classes. Before this PR, only the top 200 entries were returned for each of the endpoints. This PR makes sure all the items are fetched before returning.

In order to do so, I added a base `PrefectApiMetric` class that implements the `_get_with_pagination` method. Then, I made the other classes inherit from it (`class PrefectFlowRuns(PrefectApiMetric)` etc.) and updated the `get_all_<items>_info` methods use the new `_get_with_pagination` method, resulting in all the items being fetched.

I hope my contribution meets the guidelines - please review it and let me know about any changes requested.

Best regards,
Ohad