### PR TITLE
Add 'paused' label to 'prefect_info_deployments' metric

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   prefect:
-    image: prefecthq/prefect:2-latest
+    image: prefecthq/prefect:3-latest
     ports:
       - "4200:4200"
     environment:

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -133,8 +133,8 @@ class PrefectMetrics(object):
                     str(flow_name),
                     str(deployment.get("id", "null")),
                     # Populate the "is_schedule_active" label with the value
-                    # from the "paussed" field.
-                    str(deployment.get("paused", "null")),
+                    # from the "paused" field (negated).
+                    str(not(deployment.get("paused", "null"))),
                     str(deployment.get("name", "null")),
                     str(deployment.get("path", "null")),
                     str(deployment.get("paused", "null")),

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -100,7 +100,7 @@ class PrefectMetrics(object):
                 "flow_name",
                 "deployment_id",
                 # The "is_schedule_active" field is deprecated, and always
-                # returns Null. For backward compatibility, we will populate
+                # returns "null". For backward compatibility, we will populate
                 # the value of the this label with the "paused" field.
                 "is_schedule_active",
                 "deployment_name",

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -99,9 +99,6 @@ class PrefectMetrics(object):
                 "flow_id",
                 "flow_name",
                 "deployment_id",
-                # The "is_schedule_active" field is deprecated, and always
-                # returns "null". For backward compatibility, we will populate
-                # the value of the this label with the "paused" field.
                 "is_schedule_active",
                 "deployment_name",
                 "path",
@@ -126,15 +123,22 @@ class PrefectMetrics(object):
                     "null",
                 )
 
+            # The "is_schedule_active" field is deprecated, and always returns
+            # "null". For backward compatibility, we will populate the value of
+            # this label with the "paused" field.
+            is_schedule_active = deployment.get("paused", "null")
+            if is_schedule_active != "null":
+                # Negate the value we get from "paused" because "is_schedule_active"
+                # is the opposite of "paused".
+                is_schedule_active = not is_schedule_active
+
             prefect_info_deployments.add_metric(
                 [
                     str(deployment.get("created", "null")),
                     str(deployment.get("flow_id", "null")),
                     str(flow_name),
                     str(deployment.get("id", "null")),
-                    # Populate the "is_schedule_active" label with the value
-                    # from the "paused" field (negated).
-                    str(not(deployment.get("paused", "null"))),
+                    str(is_schedule_active),
                     str(deployment.get("name", "null")),
                     str(deployment.get("path", "null")),
                     str(deployment.get("paused", "null")),

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -99,9 +99,13 @@ class PrefectMetrics(object):
                 "flow_id",
                 "flow_name",
                 "deployment_id",
+                # The "is_schedule_active" field is deprecated, and always
+                # returns Null. For backward compatibility, we will populate
+                # the value of the this label with the "paused" field.
                 "is_schedule_active",
                 "deployment_name",
                 "path",
+                "paused",
                 "work_pool_name",
                 "work_queue_name",
                 "status",
@@ -128,9 +132,12 @@ class PrefectMetrics(object):
                     str(deployment.get("flow_id", "null")),
                     str(flow_name),
                     str(deployment.get("id", "null")),
-                    str(deployment.get("is_schedule_active", "null")),
+                    # Populate the "is_schedule_active" label with the value
+                    # from the "paussed" field.
+                    str(deployment.get("paused", "null")),
                     str(deployment.get("name", "null")),
                     str(deployment.get("path", "null")),
+                    str(deployment.get("paused", "null")),
                     str(deployment.get("work_pool_name", "null")),
                     str(deployment.get("work_queue_name", "null")),
                     str(deployment.get("status", "null")),


### PR DESCRIPTION
## Summary

- Adds the 'paused' label to the 'prefect_info_deployments' metric
- Also uses this value for the 'is_schedule_active' label, which is deprecated and always returns Null.
- Updates the docker-compose testing setup to use Prefect 3

Related to PLA-224

## Testing

I ran `docker-compose up -d` and created a deployment with a schedule:

```python
from prefect import flow

@flow
def my_flow():
    print("Hello, Prefect!")

if __name__ == "__main__":
    my_flow.serve(name="my-first-deployment-scheduled", cron="* * * * *")
```

Then I checked the prometheus metrics to confirm that `is_schedule_active` now has a value, and that it matches the opposite of the `paused` value:

<img width="867" alt="image" src="https://github.com/user-attachments/assets/d4203c1c-146d-4593-93b4-6a4f1cd57f44">

Next I paused the deployment from the UI and confirmed `paused=True` and `is_schedule_active=False`:

<img width="869" alt="image" src="https://github.com/user-attachments/assets/11d235d4-05bb-4116-948d-e38965003c82">