### PR TITLE
Chore/allow limiting of pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_API_URL` | Prefect API URL | `https://localhost:4200/api` |
 | `PREFECT_API_KEY` | Prefect API KEY (Optional) | `""` |
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
-| `PAGINATION_USAGE` | Enable pagination usage. (Uses more resources) | `False` |
+| `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `False` |
 | `PAGINATION_LIMIT` | Pagination limit | `200` |
 
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_API_URL` | Prefect API URL | `https://localhost:4200/api` |
 | `PREFECT_API_KEY` | Prefect API KEY (Optional) | `""` |
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
-| `ENABLE_PAGINATION` | Enable pagination usage. (Uses more resources) | `False` |
+| `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `False` |
 | `PAGINATION_LIMIT` | Pagination limit | `200` |
 
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ You can modify environment variables to change the behavior of the exporter.
 | `OFFSET_MINUTES` | Number of minutes to offset the start time when fetching metrics from Prefect API | `5` |
 | `PREFECT_API_URL` | Prefect API URL | `https://localhost:4200/api` |
 | `PREFECT_API_KEY` | Prefect API KEY (Optional) | `""` |
+| `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
+| `PAGINATION_USAGE` | Enable pagination usage. (Uses more resources) | `False` |
+| `PAGINATION_LIMIT` | Pagination limit | `200` |
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_API_URL` | Prefect API URL | `https://localhost:4200/api` |
 | `PREFECT_API_KEY` | Prefect API KEY (Optional) | `""` |
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
-| `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `False` |
+| `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `True` |
 | `PAGINATION_LIMIT` | Pagination limit | `200` |
 
 

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ def metrics():
         csrf_enabled=str(os.getenv("PREFECT_CSRF_ENABLED", "False")) == "True",
         logger=logger,
         # Enable pagination if not specified to avoid breaking existing deployments
-        enable_pagination=str(os.getenv("ENABLE_PAGINATION", "True")) == "True",
+        enable_pagination=str(os.getenv("PAGINATION_ENABLED", "True")) == "True",
         pagination_limit=int(os.getenv("PAGINATION_LIMIT", 200)),
     )
 

--- a/main.py
+++ b/main.py
@@ -21,7 +21,6 @@ def metrics():
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     csrf_client_id = str(uuid.uuid4())
-    pagination_limit = int(os.getenv("PAGINATION_LIMIT", "200"))
     # Configure logging
     logging.basicConfig(
         level=loglevel, format="%(asctime)s - %(name)s - [%(levelname)s] %(message)s"

--- a/main.py
+++ b/main.py
@@ -47,7 +47,8 @@ def metrics():
         client_id=csrf_client_id,
         csrf_enabled=str(os.getenv("PREFECT_CSRF_ENABLED", "False")) == "True",
         logger=logger,
-        pagination_usage=str(os.getenv("PAGINATION_USAGE", "False")) == "True",
+        # Enable pagination if not specified to avoid breaking existing deployments
+        pagination_enabled=str(os.getenv("PAGINATION_ENABLED", "True")) == "True",
         pagination_limit=int(os.getenv("PAGINATION_LIMIT", 200)),
     )
 

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def metrics():
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     csrf_client_id = str(uuid.uuid4())
-
+    pagination_limit = int(os.getenv("PAGINATION_LIMIT", "200"))
     # Configure logging
     logging.basicConfig(
         level=loglevel, format="%(asctime)s - %(name)s - [%(levelname)s] %(message)s"
@@ -48,6 +48,8 @@ def metrics():
         client_id=csrf_client_id,
         csrf_enabled=str(os.getenv("PREFECT_CSRF_ENABLED", "False")) == "True",
         logger=logger,
+        pagination_usage=str(os.getenv("PAGINATION_USAGE", "False")) == "True",
+        pagination_limit=int(os.getenv("PAGINATION_LIMIT", 200)),
     )
 
     # Register the metrics with Prometheus

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -9,7 +9,7 @@ class PrefectApiMetric:
     PrefectDeployments class for interacting with Prefect's endpoints
     """
 
-    def __init__(self, url, headers, max_retries, logger, uri) -> None:
+    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri) -> None:
         """
         Initialize the PrefectDeployments instance.
 
@@ -19,14 +19,16 @@ class PrefectApiMetric:
             max_retries (int): The maximum number of retries for HTTP requests.
             logger (obj): The logger object.
             uri (str, optional): The URI path for the intended endpoint.
-
+            pagination_usage (bool): Whether to use pagination or not.
+            pagination_limit (int): The limit for pagination.
         """
         self.headers = headers
         self.uri = uri
         self.url = url
         self.max_retries = max_retries
         self.logger = logger
-
+        self.pagination_usage = pagination_usage
+        self.pagination_limit = pagination_limit
     def _get_with_pagination(self, base_data: Optional[dict] = None) -> list:
         """
         Fetch all items from the endpoint with pagination.
@@ -35,7 +37,8 @@ class PrefectApiMetric:
             dict: JSON response containing all items from the endpoint.
         """
         endpoint = f"{self.url}/{self.uri}/filter"
-        limit = 200
+        pagination_usage = self.pagination_usage
+        limit = self.pagination_limit
         offset = 0
         all_items = []
 
@@ -60,6 +63,10 @@ class PrefectApiMetric:
                     break
 
             curr_page_items = resp.json()
+
+            # If pagination is not used, break the loop
+            if not pagination_usage:
+                break
 
             # If the current page is empty, break the loop
             if not curr_page_items:

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -10,7 +10,7 @@ class PrefectApiMetric:
     """
 
     def __init__(
-        self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri
+        self, url, headers, max_retries, logger, enable_pagination, pagination_limit, uri
     ) -> None:
         """
         Initialize the PrefectDeployments instance.

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -10,7 +10,14 @@ class PrefectApiMetric:
     """
 
     def __init__(
-        self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri
+        self,
+        url,
+        headers,
+        max_retries,
+        logger,
+        pagination_enabled,
+        pagination_limit,
+        uri,
     ) -> None:
         """
         Initialize the PrefectDeployments instance.
@@ -21,7 +28,7 @@ class PrefectApiMetric:
             max_retries (int): The maximum number of retries for HTTP requests.
             logger (obj): The logger object.
             uri (str, optional): The URI path for the intended endpoint.
-            pagination_usage (bool): Whether to use pagination or not.
+            pagination_enabled (bool): Whether to use pagination or not.
             pagination_limit (int): The limit for pagination.
         """
         self.headers = headers
@@ -29,7 +36,7 @@ class PrefectApiMetric:
         self.url = url
         self.max_retries = max_retries
         self.logger = logger
-        self.pagination_usage = pagination_usage
+        self.pagination_enabled = pagination_enabled
         self.pagination_limit = pagination_limit
 
     def _get_with_pagination(self, base_data: Optional[dict] = None) -> list:
@@ -40,7 +47,7 @@ class PrefectApiMetric:
             dict: JSON response containing all items from the endpoint.
         """
         endpoint = f"{self.url}/{self.uri}/filter"
-        pagination_usage = self.pagination_usage
+        pagination_enabled = self.pagination_enabled
         limit = self.pagination_limit
         offset = 0
         all_items = []
@@ -68,7 +75,7 @@ class PrefectApiMetric:
             curr_page_items = resp.json()
 
             # If pagination is not used, break the loop
-            if not pagination_usage:
+            if not pagination_enabled:
                 break
 
             # If the current page is empty, break the loop

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -9,7 +9,9 @@ class PrefectApiMetric:
     PrefectDeployments class for interacting with Prefect's endpoints
     """
 
-    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri) -> None:
+    def __init__(
+        self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri
+    ) -> None:
         """
         Initialize the PrefectDeployments instance.
 
@@ -29,6 +31,7 @@ class PrefectApiMetric:
         self.logger = logger
         self.pagination_usage = pagination_usage
         self.pagination_limit = pagination_limit
+
     def _get_with_pagination(self, base_data: Optional[dict] = None) -> list:
         """
         Fetch all items from the endpoint with pagination.

--- a/metrics/deployments.py
+++ b/metrics/deployments.py
@@ -12,7 +12,7 @@ class PrefectDeployments(PrefectApiMetric):
         headers,
         max_retries,
         logger,
-        pagination_usage,
+        pagination_enabled,
         pagination_limit,
         uri="deployments",
     ) -> None:
@@ -32,7 +32,7 @@ class PrefectDeployments(PrefectApiMetric):
             headers=headers,
             max_retries=max_retries,
             logger=logger,
-            pagination_usage=pagination_usage,
+            pagination_enabled=pagination_enabled,
             pagination_limit=pagination_limit,
             uri=uri,
         )

--- a/metrics/deployments.py
+++ b/metrics/deployments.py
@@ -6,7 +6,7 @@ class PrefectDeployments(PrefectApiMetric):
     PrefectDeployments class for interacting with Prefect's deployments endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, uri="deployments") -> None:
+    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="deployments") -> None:
         """
         Initialize the PrefectDeployments instance.
 
@@ -16,16 +16,16 @@ class PrefectDeployments(PrefectApiMetric):
             max_retries (int): The maximum number of retries for HTTP requests.
             logger (obj): The logger object.
             uri (str, optional): The URI path for deployments endpoints. Default is "deployments".
-
+            pagination_limit (int): The maximum number of pages to fetch.
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
         )
 
     def get_deployments_info(self) -> list:
         """
         Get information about Prefect deployments.
-
+ 
         Returns:
             dict: JSON response containing information about deployments.
 

--- a/metrics/deployments.py
+++ b/metrics/deployments.py
@@ -6,7 +6,16 @@ class PrefectDeployments(PrefectApiMetric):
     PrefectDeployments class for interacting with Prefect's deployments endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="deployments") -> None:
+    def __init__(
+        self,
+        url,
+        headers,
+        max_retries,
+        logger,
+        pagination_usage,
+        pagination_limit,
+        uri="deployments",
+    ) -> None:
         """
         Initialize the PrefectDeployments instance.
 
@@ -19,13 +28,19 @@ class PrefectDeployments(PrefectApiMetric):
             pagination_limit (int): The maximum number of pages to fetch.
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
+            url=url,
+            headers=headers,
+            max_retries=max_retries,
+            logger=logger,
+            pagination_usage=pagination_usage,
+            pagination_limit=pagination_limit,
+            uri=uri,
         )
 
     def get_deployments_info(self) -> list:
         """
         Get information about Prefect deployments.
- 
+
         Returns:
             dict: JSON response containing information about deployments.
 

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -15,7 +15,7 @@ class PrefectFlowRuns(PrefectApiMetric):
         max_retries,
         offset_minutes,
         logger,
-        pagination_usage,
+        pagination_enabled,
         pagination_limit,
         uri="flow_runs",
     ) -> None:
@@ -36,7 +36,7 @@ class PrefectFlowRuns(PrefectApiMetric):
             headers=headers,
             max_retries=max_retries,
             logger=logger,
-            pagination_usage=pagination_usage,
+            pagination_enabled=pagination_enabled,
             pagination_limit=pagination_limit,
             uri=uri,
         )

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -9,7 +9,15 @@ class PrefectFlowRuns(PrefectApiMetric):
     """
 
     def __init__(
-        self, url, headers, max_retries, offset_minutes, logger, pagination_usage, pagination_limit, uri="flow_runs"
+        self,
+        url,
+        headers,
+        max_retries,
+        offset_minutes,
+        logger,
+        pagination_usage,
+        pagination_limit,
+        uri="flow_runs",
     ) -> None:
         """
         Initialize the PrefectFlowRuns instance.
@@ -24,7 +32,13 @@ class PrefectFlowRuns(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
+            url=url,
+            headers=headers,
+            max_retries=max_retries,
+            logger=logger,
+            pagination_usage=pagination_usage,
+            pagination_limit=pagination_limit,
+            uri=uri,
         )
 
         # Calculate timestamps for before and after data

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -9,7 +9,7 @@ class PrefectFlowRuns(PrefectApiMetric):
     """
 
     def __init__(
-        self, url, headers, max_retries, offset_minutes, logger, uri="flow_runs"
+        self, url, headers, max_retries, offset_minutes, logger, pagination_usage, pagination_limit, uri="flow_runs"
     ) -> None:
         """
         Initialize the PrefectFlowRuns instance.
@@ -24,7 +24,7 @@ class PrefectFlowRuns(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
         )
 
         # Calculate timestamps for before and after data

--- a/metrics/flows.py
+++ b/metrics/flows.py
@@ -6,7 +6,16 @@ class PrefectFlows(PrefectApiMetric):
     PrefectFlows class for interacting with Prefect's flows endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="flows") -> None:
+    def __init__(
+        self,
+        url,
+        headers,
+        max_retries,
+        logger,
+        pagination_usage,
+        pagination_limit,
+        uri="flows",
+    ) -> None:
         """
         Initialize the PrefectFlows instance.
 
@@ -19,7 +28,13 @@ class PrefectFlows(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
+            url=url,
+            headers=headers,
+            max_retries=max_retries,
+            logger=logger,
+            pagination_usage=pagination_usage,
+            pagination_limit=pagination_limit,
+            uri=uri,
         )
 
     def get_flows_info(self) -> list:

--- a/metrics/flows.py
+++ b/metrics/flows.py
@@ -6,7 +6,7 @@ class PrefectFlows(PrefectApiMetric):
     PrefectFlows class for interacting with Prefect's flows endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, uri="flows") -> None:
+    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="flows") -> None:
         """
         Initialize the PrefectFlows instance.
 
@@ -19,7 +19,7 @@ class PrefectFlows(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
         )
 
     def get_flows_info(self) -> list:

--- a/metrics/flows.py
+++ b/metrics/flows.py
@@ -12,7 +12,7 @@ class PrefectFlows(PrefectApiMetric):
         headers,
         max_retries,
         logger,
-        pagination_usage,
+        pagination_enabled,
         pagination_limit,
         uri="flows",
     ) -> None:
@@ -32,7 +32,7 @@ class PrefectFlows(PrefectApiMetric):
             headers=headers,
             max_retries=max_retries,
             logger=logger,
-            pagination_usage=pagination_usage,
+            pagination_enabled=pagination_enabled,
             pagination_limit=pagination_limit,
             uri=uri,
         )

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -16,7 +16,16 @@ class PrefectMetrics(object):
     """
 
     def __init__(
-        self, url, headers, offset_minutes, max_retries, csrf_enabled, client_id, logger, pagination_usage, pagination_limit
+        self,
+        url,
+        headers,
+        offset_minutes,
+        max_retries,
+        csrf_enabled,
+        client_id,
+        logger,
+        pagination_usage,
+        pagination_limit,
     ) -> None:
         """
         Initialize the PrefectMetrics instance.
@@ -71,22 +80,54 @@ class PrefectMetrics(object):
         # PREFECT GET RESOURCES
         #
         deployments = PrefectDeployments(
-            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.logger,
+            self.pagination_usage,
+            self.pagination_limit,
         ).get_deployments_info()
         flows = PrefectFlows(
-            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.logger,
+            self.pagination_usage,
+            self.pagination_limit,
         ).get_flows_info()
         flow_runs = PrefectFlowRuns(
-            self.url, self.headers, self.max_retries, self.offset_minutes, self.logger, self.pagination_usage, self.pagination_limit
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.offset_minutes,
+            self.logger,
+            self.pagination_usage,
+            self.pagination_limit,
         ).get_flow_runs_info()
         all_flow_runs = PrefectFlowRuns(
-            self.url, self.headers, self.max_retries, self.offset_minutes, self.logger, self.pagination_usage, self.pagination_limit
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.offset_minutes,
+            self.logger,
+            self.pagination_usage,
+            self.pagination_limit,
         ).get_all_flow_runs_info()
         work_pools = PrefectWorkPools(
-            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.logger,
+            self.pagination_usage,
+            self.pagination_limit,
         ).get_work_pools_info()
         work_queues = PrefectWorkQueues(
-            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.logger,
+            self.pagination_usage,
+            self.pagination_limit,
         ).get_work_queues_info()
 
         ##

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -24,7 +24,7 @@ class PrefectMetrics(object):
         csrf_enabled,
         client_id,
         logger,
-        pagination_usage,
+        pagination_enabled,
         pagination_limit,
     ) -> None:
         """
@@ -45,7 +45,7 @@ class PrefectMetrics(object):
         self.logger = logger
         self.client_id = client_id
         self.csrf_enabled = csrf_enabled
-        self.pagination_usage = pagination_usage
+        self.pagination_enabled = pagination_enabled
         self.pagination_limit = pagination_limit
         self.csrf_token = None
         self.csrf_token_expiration = None
@@ -71,7 +71,7 @@ class PrefectMetrics(object):
         ##
         # NOTIFY IF PAGINATION IS ENABLED
         #
-        if self.pagination_usage:
+        if self.pagination_enabled:
             self.logger.info("Pagination is enabled")
             self.logger.info(f"Pagination limit is {self.pagination_limit}")
         else:
@@ -84,7 +84,7 @@ class PrefectMetrics(object):
             self.headers,
             self.max_retries,
             self.logger,
-            self.pagination_usage,
+            self.pagination_enabled,
             self.pagination_limit,
         ).get_deployments_info()
         flows = PrefectFlows(
@@ -92,7 +92,7 @@ class PrefectMetrics(object):
             self.headers,
             self.max_retries,
             self.logger,
-            self.pagination_usage,
+            self.pagination_enabled,
             self.pagination_limit,
         ).get_flows_info()
         flow_runs = PrefectFlowRuns(
@@ -101,7 +101,7 @@ class PrefectMetrics(object):
             self.max_retries,
             self.offset_minutes,
             self.logger,
-            self.pagination_usage,
+            self.pagination_enabled,
             self.pagination_limit,
         ).get_flow_runs_info()
         all_flow_runs = PrefectFlowRuns(
@@ -110,7 +110,7 @@ class PrefectMetrics(object):
             self.max_retries,
             self.offset_minutes,
             self.logger,
-            self.pagination_usage,
+            self.pagination_enabled,
             self.pagination_limit,
         ).get_all_flow_runs_info()
         work_pools = PrefectWorkPools(
@@ -118,7 +118,7 @@ class PrefectMetrics(object):
             self.headers,
             self.max_retries,
             self.logger,
-            self.pagination_usage,
+            self.pagination_enabled,
             self.pagination_limit,
         ).get_work_pools_info()
         work_queues = PrefectWorkQueues(
@@ -126,7 +126,7 @@ class PrefectMetrics(object):
             self.headers,
             self.max_retries,
             self.logger,
-            self.pagination_usage,
+            self.pagination_enabled,
             self.pagination_limit,
         ).get_work_queues_info()
 

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -16,7 +16,7 @@ class PrefectMetrics(object):
     """
 
     def __init__(
-        self, url, headers, offset_minutes, max_retries, csrf_enabled, client_id, logger
+        self, url, headers, offset_minutes, max_retries, csrf_enabled, client_id, logger, pagination_usage, pagination_limit
     ) -> None:
         """
         Initialize the PrefectMetrics instance.
@@ -36,6 +36,8 @@ class PrefectMetrics(object):
         self.logger = logger
         self.client_id = client_id
         self.csrf_enabled = csrf_enabled
+        self.pagination_usage = pagination_usage
+        self.pagination_limit = pagination_limit
         self.csrf_token = None
         self.csrf_token_expiration = None
 
@@ -58,25 +60,33 @@ class PrefectMetrics(object):
             self.headers["Prefect-Csrf-Token"] = self.csrf_token
             self.headers["Prefect-Csrf-Client"] = self.client_id
         ##
+        # NOTIFY IF PAGINATION IS ENABLED
+        #
+        if self.pagination_usage:
+            self.logger.info("Pagination is enabled")
+            self.logger.info(f"Pagination limit is {self.pagination_limit}")
+        else:
+            self.logger.info("Pagination is disabled")
+        ##
         # PREFECT GET RESOURCES
         #
         deployments = PrefectDeployments(
-            self.url, self.headers, self.max_retries, self.logger
+            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
         ).get_deployments_info()
         flows = PrefectFlows(
-            self.url, self.headers, self.max_retries, self.logger
+            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
         ).get_flows_info()
         flow_runs = PrefectFlowRuns(
-            self.url, self.headers, self.max_retries, self.offset_minutes, self.logger
+            self.url, self.headers, self.max_retries, self.offset_minutes, self.logger, self.pagination_usage, self.pagination_limit
         ).get_flow_runs_info()
         all_flow_runs = PrefectFlowRuns(
-            self.url, self.headers, self.max_retries, self.offset_minutes, self.logger
+            self.url, self.headers, self.max_retries, self.offset_minutes, self.logger, self.pagination_usage, self.pagination_limit
         ).get_all_flow_runs_info()
         work_pools = PrefectWorkPools(
-            self.url, self.headers, self.max_retries, self.logger
+            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
         ).get_work_pools_info()
         work_queues = PrefectWorkQueues(
-            self.url, self.headers, self.max_retries, self.logger
+            self.url, self.headers, self.max_retries, self.logger, self.pagination_usage, self.pagination_limit
         ).get_work_queues_info()
 
         ##

--- a/metrics/work_pools.py
+++ b/metrics/work_pools.py
@@ -6,7 +6,7 @@ class PrefectWorkPools(PrefectApiMetric):
     PrefectWorkPools class for interacting with Prefect's work pools endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, uri="work_pools") -> None:
+    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="work_pools") -> None:
         """
         Initialize the PrefectWorkPools instance.
 
@@ -19,7 +19,7 @@ class PrefectWorkPools(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
         )
 
     def get_work_pools_info(self) -> list:

--- a/metrics/work_pools.py
+++ b/metrics/work_pools.py
@@ -12,7 +12,7 @@ class PrefectWorkPools(PrefectApiMetric):
         headers,
         max_retries,
         logger,
-        pagination_usage,
+        pagination_enabled,
         pagination_limit,
         uri="work_pools",
     ) -> None:
@@ -32,7 +32,7 @@ class PrefectWorkPools(PrefectApiMetric):
             headers=headers,
             max_retries=max_retries,
             logger=logger,
-            pagination_usage=pagination_usage,
+            pagination_enabled=pagination_enabled,
             pagination_limit=pagination_limit,
             uri=uri,
         )

--- a/metrics/work_pools.py
+++ b/metrics/work_pools.py
@@ -6,7 +6,16 @@ class PrefectWorkPools(PrefectApiMetric):
     PrefectWorkPools class for interacting with Prefect's work pools endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="work_pools") -> None:
+    def __init__(
+        self,
+        url,
+        headers,
+        max_retries,
+        logger,
+        pagination_usage,
+        pagination_limit,
+        uri="work_pools",
+    ) -> None:
         """
         Initialize the PrefectWorkPools instance.
 
@@ -19,7 +28,13 @@ class PrefectWorkPools(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
+            url=url,
+            headers=headers,
+            max_retries=max_retries,
+            logger=logger,
+            pagination_usage=pagination_usage,
+            pagination_limit=pagination_limit,
+            uri=uri,
         )
 
     def get_work_pools_info(self) -> list:

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -11,7 +11,16 @@ class PrefectWorkQueues(PrefectApiMetric):
     PrefectWorkQueues class for interacting with Prefect's work queues endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="work_queues") -> None:
+    def __init__(
+        self,
+        url,
+        headers,
+        max_retries,
+        logger,
+        pagination_usage,
+        pagination_limit,
+        uri="work_queues",
+    ) -> None:
         """
         Initialize the PrefectWorkQueues instance.
 
@@ -24,7 +33,13 @@ class PrefectWorkQueues(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
+            url=url,
+            headers=headers,
+            max_retries=max_retries,
+            logger=logger,
+            pagination_usage=pagination_usage,
+            pagination_limit=pagination_limit,
+            uri=uri,
         )
 
     def get_work_queues_info(self) -> list:

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -11,7 +11,7 @@ class PrefectWorkQueues(PrefectApiMetric):
     PrefectWorkQueues class for interacting with Prefect's work queues endpoints.
     """
 
-    def __init__(self, url, headers, max_retries, logger, uri="work_queues") -> None:
+    def __init__(self, url, headers, max_retries, logger, pagination_usage, pagination_limit, uri="work_queues") -> None:
         """
         Initialize the PrefectWorkQueues instance.
 
@@ -24,7 +24,7 @@ class PrefectWorkQueues(PrefectApiMetric):
 
         """
         super().__init__(
-            url=url, headers=headers, max_retries=max_retries, logger=logger, uri=uri
+            url=url, headers=headers, max_retries=max_retries, logger=logger, pagination_usage=pagination_usage, pagination_limit=pagination_limit, uri=uri
         )
 
     def get_work_queues_info(self) -> list:

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -17,7 +17,7 @@ class PrefectWorkQueues(PrefectApiMetric):
         headers,
         max_retries,
         logger,
-        pagination_usage,
+        pagination_enabled,
         pagination_limit,
         uri="work_queues",
     ) -> None:
@@ -37,7 +37,7 @@ class PrefectWorkQueues(PrefectApiMetric):
             headers=headers,
             max_retries=max_retries,
             logger=logger,
-            pagination_usage=pagination_usage,
+            pagination_enabled=pagination_enabled,
             pagination_limit=pagination_limit,
             uri=uri,
         )


### PR DESCRIPTION
- Relates to: https://linear.app/prefect/issue/PLA-364/exporter-oomkilled
- Pagination is a great feature to ensure that we are able to pull all metrics from our prefect servers if desired.  However, all of this data can cause exporter OOMs.
- We are now allowing for pagination to be turned off and to limit the number of pages that are pulled to help with memory utilization. 