### PR TITLE
Add the ability to control the exporter webserver address used

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,18 @@ You can modify environment variables to change the behavior of the exporter.
 - An API Key is only required for auth-enabled, on-prem, self-managed solutions.
 - An API key is not required for open-source or Prefect Server.
 
-| Environment Variable | Description | Default |
-| --- | --- | --- |
-| `LOG_LEVEL` | Logging level | `INFO` |
-| `MAX_RETRIES` | Number of retries to attempt when fetching metrics from Prefect API | `3` |
-| `METRICS_PORT` | Port to expose metrics on | `8000` |
-| `OFFSET_MINUTES` | Number of minutes to offset the start time when fetching metrics from Prefect API | `5` |
-| `PREFECT_API_URL` | Prefect API URL | `https://localhost:4200/api` |
-| `PREFECT_API_KEY` | Prefect API KEY (Optional) | `""` |
-| `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
-| `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `True` |
-| `PAGINATION_LIMIT` | Pagination limit | `200` |
+| Environment Variable   | Description                                                                       | Default                      |
+|------------------------|-----------------------------------------------------------------------------------|------------------------------|
+| `LOG_LEVEL`            | Logging level                                                                     | `INFO`                       |
+| `MAX_RETRIES`          | Number of retries to attempt when fetching metrics from Prefect API               | `3`                          |
+| `METRICS_ADDR`         | Address to expose metrics on                                                      | `0.0.0.0`                    |
+| `METRICS_PORT`         | Port to expose metrics on                                                         | `8000`                       |
+| `OFFSET_MINUTES`       | Number of minutes to offset the start time when fetching metrics from Prefect API | `5`                          |
+| `PREFECT_API_URL`      | Prefect API URL                                                                   | `https://localhost:4200/api` |
+| `PREFECT_API_KEY`      | Prefect API KEY (Optional)                                                        | `""`                         |
+| `PREFECT_CSRF_ENABLED` | Enable compatibility with Prefect Servers using CSRF protection                   | `False`                      |
+| `PAGINATION_ENABLED`   | Enable pagination usage. (Uses more resources)                                    | `True`                       |
+| `PAGINATION_LIMIT`     | Pagination limit                                                                  | `200`                        |
 
 
 ## Contributing

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ def metrics():
     # Get environment variables or use default values
     loglevel = str(os.getenv("LOG_LEVEL", "INFO"))
     max_retries = int(os.getenv("MAX_RETRIES", "3"))
+    metrics_addr = os.getenv("METRICS_ADDR", "0.0.0.0")
     metrics_port = int(os.getenv("METRICS_PORT", "8000"))
     offset_minutes = int(os.getenv("OFFSET_MINUTES", "5"))
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
@@ -68,8 +69,8 @@ def metrics():
     REGISTRY.register(metrics)
 
     # Start the HTTP server to expose Prometheus metrics
-    start_http_server(metrics_port)
-    logger.info(f"Exporter listening on port :{metrics_port}")
+    start_http_server(metrics_port, metrics_addr)
+    logger.info(f"Exporter listening on {metrics_addr}:{metrics_port}")
 
     # Run the loop to collect Prefect metrics
     while True:


### PR DESCRIPTION
Prior to this change, start_http_server was called without explicit addr parameter, defaulting to prometheus_client addr="0.0.0.0"

For some reason (security), one might want to use a different address (127.0.0.1 for example)

This PR optionally allows setting bind address by setting the METRICS_ADDR environment variable

For backward compatibility the default value is kept "0.0.0.0"