### PR TITLE
fix/Total run time metrics should be bounded by the offset minutes similar to flow run info

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
 | `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `True` |
 | `PAGINATION_LIMIT` | Pagination limit | `200` |
+| `SCRAPE_INTERVAL_SECONDS` | Interval in seconds to scrape metrics from Prefect API | `30` |
 
 
 ## Contributing

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def metrics():
     loglevel = str(os.getenv("LOG_LEVEL", "INFO"))
     max_retries = int(os.getenv("MAX_RETRIES", "3"))
     metrics_port = int(os.getenv("METRICS_PORT", "8000"))
-    offset_minutes = int(os.getenv("OFFSET_MINUTES", "5"))
+    offset_minutes = int(os.getenv("OFFSET_MINUTES", "3"))
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     csrf_client_id = str(uuid.uuid4())
@@ -73,7 +73,7 @@ def metrics():
 
     # Run the loop to collect Prefect metrics
     while True:
-        time.sleep(5)
+        time.sleep(30)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def metrics():
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     csrf_client_id = str(uuid.uuid4())
+    scrape_interval_seconds = int(os.getenv("SCRAPE_INTERVAL_SECONDS", "30"))
     # Configure logging
     logging.basicConfig(
         level=loglevel, format="%(asctime)s - %(name)s - [%(levelname)s] %(message)s"
@@ -73,7 +74,7 @@ def metrics():
 
     # Run the loop to collect Prefect metrics
     while True:
-        time.sleep(30)
+        time.sleep(scrape_interval_seconds)
 
 
 if __name__ == "__main__":

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -71,6 +71,13 @@ class PrefectFlowRuns(PrefectApiMetric):
         Returns:
             dict: JSON response containing flow runs information.
         """
-        all_flow_runs = self._get_with_pagination()
+        all_flow_runs = self._get_with_pagination(
+            base_data={
+                "flow_runs": {
+                    "operator": "and_",
+                    "end_time": {"after_": f"{self.after_data_fmt}"},
+                }
+            }
+        )
 
         return all_flow_runs

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -41,6 +41,7 @@ class PrefectMetrics(object):
             enable_pagination (bool): Whether pagination is enabled.
             pagination_limit (int): The pagination limit.
         """
+
         self.headers = headers
         self.offset_minutes = offset_minutes
         self.url = url
@@ -284,6 +285,7 @@ class PrefectMetrics(object):
 
         yield prefect_flow_runs_total_run_time
 
+        # prefect_info_flow_runs metric
         prefect_info_flow_runs = GaugeMetricFamily(
             "prefect_info_flow_runs",
             "Prefect flow runs info",

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -36,7 +36,10 @@ class PrefectMetrics(object):
             offset_minutes (int): Time offset in minutes.
             max_retries (int): The maximum number of retries for HTTP requests.
             logger (obj): The logger object.
-
+            csrf_enabled (bool): Whether CSRF is enabled.
+            client_id (str): The client ID for CSRF.
+            enable_pagination (bool): Whether pagination is enabled.
+            pagination_limit (int): The pagination limit.
         """
         self.headers = headers
         self.offset_minutes = offset_minutes
@@ -281,7 +284,6 @@ class PrefectMetrics(object):
 
         yield prefect_flow_runs_total_run_time
 
-        # prefect_info_flow_runs metric
         prefect_info_flow_runs = GaugeMetricFamily(
             "prefect_info_flow_runs",
             "Prefect flow runs info",


### PR DESCRIPTION
- Resolves: https://linear.app/prefect/issue/PLA-782/fetching-all-flow-runs-causes-oom-issues-as-the-data-is-not-tied-to
- Existing deployments of the exporter have an issue where `prefect_flow_runs_total_run_time_total` can grow continuously as the request was not bounded by any sort of time interval similar to other requests.  This would lead to an eventual OOM of the exporter as it tries to fetch more data as the prefect instance grows.
- Offset minute defaults as well as the scrape interval were also adjusted to put less strain on the exporter and the prefect server since we are potentially pulling a lot of data at one time.
- Example metrics:
<img width="1512" alt="metrics-output" src="https://github.com/user-attachments/assets/9d6dcbc3-34fc-4648-8bc1-a953a26c7470" />

<img width="1469" alt="prometheus-output" src="https://github.com/user-attachments/assets/885f9d76-d562-4d9b-948d-98c40615c2fa" />

<img width="1204" alt="Screenshot 2024-12-18 at 5 39 56 PM" src="https://github.com/user-attachments/assets/4632bc4f-1e6c-4086-8c40-41e0c36acbb0" />
