### PR TITLE
feat(auth): support basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can now reach each service locally:
 You can modify environment variables to change the behavior of the exporter.
 - An API Key is only required for auth-enabled, on-prem, self-managed solutions.
 - An API key is not required for open-source or Prefect Server.
+- If an API key and API auth string are provided, then the API key takes precedence.
 
 | Environment Variable | Description | Default |
 | --- | --- | --- |
@@ -101,7 +102,8 @@ You can modify environment variables to change the behavior of the exporter.
 | `METRICS_PORT` | Port to expose metrics on | `8000` |
 | `OFFSET_MINUTES` | Number of minutes to offset the start time when fetching metrics from Prefect API | `5` |
 | `PREFECT_API_URL` | Prefect API URL | `https://localhost:4200/api` |
-| `PREFECT_API_KEY` | Prefect API KEY (Optional) | `""` |
+| `PREFECT_API_KEY` | Prefect API key (Optional) | `""` |
+| `PREFECT_API_AUTH_STRING` | Prefect API auth string, automatically base64-encoded (Optional) | `""` |
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
 | `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `True` |
 | `PAGINATION_LIMIT` | Pagination limit | `200` |

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,7 @@ services:
       - "4200:4200"
     environment:
       PREFECT_LOGGING_LEVEL: debug
+      # PREFECT_SERVER_API_AUTH_STRING: ""
     command:
       - prefect
       - server
@@ -23,6 +24,7 @@ services:
       - "8000:8000"
     environment:
       PREFECT_API_URL: http://prefect:4200/api
+      # PREFECT_API_AUTH_STRING: ""
     depends_on:
       prefect:
         condition: service_healthy

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import base64
 import logging
 import time
 import uuid
@@ -21,6 +22,7 @@ def metrics():
     offset_minutes = int(os.getenv("OFFSET_MINUTES", "3"))
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
+    api_auth_string = str(os.getenv("PREFECT_API_AUTH_STRING", ""))
     csrf_client_id = str(uuid.uuid4())
     scrape_interval_seconds = int(os.getenv("SCRAPE_INTERVAL_SECONDS", "30"))
     # Configure logging
@@ -32,8 +34,14 @@ def metrics():
     # Configure headers for HTTP requests
     headers = {"accept": "application/json", "Content-Type": "application/json"}
 
+    if api_auth_string:
+        api_auth_string_encoded = base64.b64encode(api_auth_string.encode("utf-8")).decode("utf-8")
+        headers["Authorization"] = f"Basic {api_auth_string_encoded}"
+        logger.info("Added Basic Authorization header for PREFECT_API_AUTH_STRING")
+
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+        logger.info("Added Bearer Authorization header for PREFECT_API_KEY")
 
     # check endpoint
     PrefectHealthz(


### PR DESCRIPTION
## Summary

In https://github.com/PrefectHQ/prefect/pull/16408, Prefect server added support for basic auth.

This adds support for setting PREFECT_API_AUTH_STRING. The exporter will base64 encode this value and apply the value as a Basic auth header.

Closes https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/59

Closes https://linear.app/prefect/issue/PLA-931/prometheus-prefect-exporter-doesnt-support-basic-authentication-when

## Testing

Supply the authorization setting to the server and the client (exporter in this case):

```diff
diff --git a/compose.yml b/compose.yml
index f71c1da..d439195 100644
--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,7 @@ services:
       - "4200:4200"
     environment:
       PREFECT_LOGGING_LEVEL: debug
-      # PREFECT_SERVER_API_AUTH_STRING: ""
+      PREFECT_SERVER_API_AUTH_STRING: "admin:admin"
     command:
       - prefect
       - server
@@ -24,7 +24,7 @@ services:
       - "8000:8000"
     environment:
       PREFECT_API_URL: http://prefect:4200/api
-      # PREFECT_API_AUTH_STRING: ""
+      PREFECT_API_AUTH_STRING: "admin:admin"
     depends_on:
       prefect:
         condition: service_healthy
```

Then run `docker compose up -d`. This should build the exporter image, but if you need to refresh that image, run `docker compose build`.

Check the logs with `docker compose logs -f`. You should see successful requests to the endpoints:

```
...
prefect-1              | INFO:     172.30.0.4:55276 - "POST /api/flows/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55286 - "POST /api/flows/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55298 - "POST /api/flow_runs/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55314 - "POST /api/flow_runs/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55318 - "POST /api/flow_runs/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55332 - "POST /api/flow_runs/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55344 - "POST /api/work_pools/filter HTTP/1.1" 200 OK
prefect-1              | INFO:     172.30.0.4:55346 - "POST /api/work_queues/filter HTTP/1.1" 200 OK
...
```

And if you run some test flows, you should see metrics update at `http://localhost:8000`.

If you want to confirm auth is active, you can go to `http://localhost:4200` and you should see an authorization window asking for the password before you can reach the UI.