### PR TITLE
fix headers in get_csrf_token

### DIFF
--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -472,6 +472,7 @@ class PrefectMetrics(object):
         for retry in range(self.max_retries):
             try:
                 csrf_token = requests.get(
+                    headers=self.headers,
                     f"{self.url}/csrf-token?client={self.client_id}"
                 )
             except requests.exceptions.HTTPError as err:

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -472,8 +472,8 @@ class PrefectMetrics(object):
         for retry in range(self.max_retries):
             try:
                 csrf_token = requests.get(
-                    headers=self.headers,
-                    f"{self.url}/csrf-token?client={self.client_id}"
+                    f"{self.url}/csrf-token?client={self.client_id}",
+                    headers=self.headers
                 )
             except requests.exceptions.HTTPError as err:
                 self.logger.error(err)


### PR DESCRIPTION
This ensures that Authorization header from PREFECT_API_AUTH_STRING is set as necessary when retrieving the csrf token.