### PR TITLE
fix: remove scrape_interval_seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
 | `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `True` |
 | `PAGINATION_LIMIT` | Pagination limit | `200` |
-| `SCRAPE_INTERVAL_SECONDS` | Interval in seconds to scrape metrics from Prefect API | `30` |
 
 
 ## Contributing

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import os
 import base64
 import logging
-import time
+import threading
 import uuid
 
 from metrics.metrics import PrefectMetrics
@@ -24,7 +24,6 @@ def metrics():
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     api_auth_string = str(os.getenv("PREFECT_API_AUTH_STRING", ""))
     csrf_client_id = str(uuid.uuid4())
-    scrape_interval_seconds = int(os.getenv("SCRAPE_INTERVAL_SECONDS", "30"))
     # Configure logging
     logging.basicConfig(
         level=loglevel, format="%(asctime)s - %(name)s - [%(levelname)s] %(message)s"
@@ -81,9 +80,11 @@ def metrics():
     start_http_server(metrics_port, metrics_addr)
     logger.info(f"Exporter listening on {metrics_addr}:{metrics_port}")
 
-    # Run the loop to collect Prefect metrics
-    while True:
-        time.sleep(scrape_interval_seconds)
+    # Keep the process alive
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Keep the time-based filtering (the real fix from PR #57)
2. Remove misleading SCRAPE_INTERVAL_SECONDS
3. Replace the sleep loop with proper process lifecycle management

Related to https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/76

Related to https://github.com/PrefectHQ/prometheus-prefect-exporter/pull/57

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/8bf82dcf-c489-4ee6-bc55-331097bb5ae6" />



<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review
