### PR TITLE
refactor: use alternative query endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,20 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /app
-COPY ./ ./
+
 ENV PREFECT_HOME=/app
 ENV PREFECT_LOGGING_EXTRA_LOGGERS=prometheus-prefect-exporter
 ENV PREFECT_LOGGING_TO_API_ENABLED=False
+
+COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install \
       --disable-pip-version-check \
       --no-cache-dir \
       --no-color \
       --requirement requirements.txt
+
+COPY ./ ./
 
 EXPOSE 8000
 USER nobody

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -88,3 +88,56 @@ class PrefectApiMetric:
             offset += limit
 
         return all_items
+
+    def _post(self, data: Optional[dict] = None) -> list:
+        """
+        Make a direct POST request to the endpoint.
+
+        Args:
+            data (dict): Request payload.
+
+        Returns:
+            list: JSON response from the endpoint.
+        """
+        endpoint = f"{self.url}/{self.uri}/filter"
+        
+        for retry in range(self.max_retries):
+            try:
+                resp = requests.post(endpoint, headers=self.headers, json=data or {})
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as err:
+                self.logger.error(err)
+                if retry >= self.max_retries - 1:
+                    time.sleep(1)
+                    raise SystemExit(err)
+            else:
+                break
+
+        return resp.json()
+
+    def _post_to_endpoint(self, endpoint_suffix: str, data: Optional[dict] = None) -> list:
+        """
+        Make a POST request to a specific endpoint suffix.
+
+        Args:
+            endpoint_suffix (str): The endpoint suffix (e.g., 'minimal', 'history').
+            data (dict): Request payload.
+
+        Returns:
+            list: JSON response from the endpoint.
+        """
+        endpoint = f"{self.url}/{self.uri}/{endpoint_suffix}"
+        
+        for retry in range(self.max_retries):
+            try:
+                resp = requests.post(endpoint, headers=self.headers, json=data or {})
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as err:
+                self.logger.error(err)
+                if retry >= self.max_retries - 1:
+                    time.sleep(1)
+                    raise SystemExit(err)
+            else:
+                break
+
+        return resp.json()

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -100,7 +100,7 @@ class PrefectApiMetric:
             list: JSON response from the endpoint.
         """
         endpoint = f"{self.url}/{self.uri}/filter"
-        
+
         for retry in range(self.max_retries):
             try:
                 resp = requests.post(endpoint, headers=self.headers, json=data or {})
@@ -115,7 +115,9 @@ class PrefectApiMetric:
 
         return resp.json()
 
-    def _post_to_endpoint(self, endpoint_suffix: str, data: Optional[dict] = None) -> list:
+    def _post_to_endpoint(
+        self, endpoint_suffix: str, data: Optional[dict] = None
+    ) -> dict:
         """
         Make a POST request to a specific endpoint suffix.
 
@@ -127,7 +129,7 @@ class PrefectApiMetric:
             list: JSON response from the endpoint.
         """
         endpoint = f"{self.url}/{self.uri}/{endpoint_suffix}"
-        
+
         for retry in range(self.max_retries):
             try:
                 resp = requests.post(endpoint, headers=self.headers, json=data or {})

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -103,11 +103,11 @@ class PrefectMetrics(object):
             self.enable_pagination,
             self.pagination_limit,
         )
-        
+
         # Get recent flow runs (within time window) for detailed metrics
         flow_runs = flow_runs_client.get_flow_runs_info()
-        
-        # Use minimal endpoint for total count and run time metrics (memory efficient)
+
+        # Use count endpoint for total count and filter endpoint for run time metrics (compatible with Cloud and OSS)
         flow_runs_count = flow_runs_client.get_flow_runs_count()
         minimal_flow_runs = flow_runs_client.get_flow_runs_minimal()
         work_pools = PrefectWorkPools(
@@ -246,7 +246,7 @@ class PrefectMetrics(object):
         prefect_flow_runs.add_metric([], flow_runs_count)
         yield prefect_flow_runs
 
-        # prefect_flow_runs_total_run_time metric using minimal endpoint (memory efficient)
+        # prefect_flow_runs_total_run_time metric using filter endpoint (compatible with Cloud and OSS)
         prefect_flow_runs_total_run_time = CounterMetricFamily(
             "prefect_flow_runs_total_run_time",
             "Prefect flow-run total run time in seconds",


### PR DESCRIPTION
Uses alternative endpoints to help us collect meta information without having to retrieve as much data, iterate through, and total it.

Related to https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/76

See also https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/52

<!-- Add a brief description of your change here -->

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [ ] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review
