### PR TITLE
chore: address some linter suggestions

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       PREFECT_LOGGING_LEVEL: debug
       # PREFECT_SERVER_API_AUTH_STRING: ""
+      # PREFECT_SERVER_API_CSRF_PROTECTION_ENABLED: "True"
+      # PREFECT_SERVER_CSRF_PROTECTION_ENABLED: "True"
     command:
       - prefect
       - server
@@ -25,6 +27,7 @@ services:
     environment:
       PREFECT_API_URL: http://prefect:4200/api
       # PREFECT_API_AUTH_STRING: ""
+      # PREFECT_CSRF_ENABLED: "True"
     depends_on:
       prefect:
         condition: service_healthy

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -54,6 +54,8 @@ class PrefectApiMetric:
 
         # Run the loop until the current page is empty
         while True:
+            resp = requests.Response()
+
             for retry in range(self.max_retries):
                 data = {
                     **(base_data or {}),

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -477,6 +477,8 @@ class PrefectMetrics(object):
         Pull CSRF Token from CSRF Endpoint.
 
         """
+        csrf_token = requests.Response()
+
         for retry in range(self.max_retries):
             try:
                 csrf_token = requests.get(

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -1,6 +1,6 @@
 import time
+from datetime import datetime, timezone
 
-import pendulum
 import requests
 from prefect.client.schemas.objects import CsrfToken
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
@@ -65,7 +65,10 @@ class PrefectMetrics(object):
         # PREFECT GET CSRF TOKEN IF ENABLED
         #
         if self.csrf_enabled:
-            if not self.csrf_token or pendulum.now("UTC") > self.csrf_token_expiration:
+            if not self.csrf_token or (
+                self.csrf_token_expiration is not None
+                and datetime.now(timezone.utc) > self.csrf_token_expiration
+            ):
                 self.logger.info(
                     "CSRF Token is expired or has not been generated yet. Fetching new CSRF Token..."
                 )

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -495,4 +495,5 @@ class PrefectMetrics(object):
                     raise SystemExit(err)
             else:
                 break
-        return CsrfToken.parse_obj(csrf_token.json())
+
+        return CsrfToken.model_validate(csrf_token.json())

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -291,7 +291,7 @@ class PrefectMetrics(object):
                     str(flow_name),
                     str(flow_run.get("name", "null")),
                 ],
-                str(flow_run.get("total_run_time", "null")),
+                flow_run.get("total_run_time", "null"),
             )
 
         yield prefect_flow_runs_total_run_time

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -71,6 +71,7 @@ class PrefectWorkQueues(PrefectApiMetric):
 
         """
         endpoint = f"{self.url}/{self.uri}/{work_queue_id}/status"
+        resp = requests.Response()
 
         for retry in range(self.max_retries):
             try:


### PR DESCRIPTION
### Summary

Just addressing a few linter suggestions that came up when investigating other issues. Also adds placeholders for testing CSRF for convenience.

#### Test: ensure total run time metric still works

```
$ curl -s http://localhost:8000 | grep run_time_total
# HELP prefect_flow_runs_total_run_time_total Prefect flow-run total run time in seconds
# TYPE prefect_flow_runs_total_run_time_total counter
prefect_flow_runs_total_run_time_total{flow_id="b0798643-1c06-4b89-a6e5-546e3b0b96c9",flow_name="hello-world",flow_run_name="papaya-woodlouse"} 3.036167
prefect_flow_runs_total_run_time_total{flow_id="b0798643-1c06-4b89-a6e5-546e3b0b96c9",flow_name="hello-world",flow_run_name="magnificent-angelfish"} 9.045479
prefect_flow_runs_total_run_time_total{flow_id="b0798643-1c06-4b89-a6e5-546e3b0b96c9",flow_name="hello-world",flow_run_name="imported-unicorn"} 4.029114
```

#### Test: ensure CSRF logic still works

```
$ docker compose logs prometheus-exporter
prometheus-exporter-1  | 2025-07-02 01:53:39,771 - prometheus-prefect-exporter - [INFO] Prefect health check: 200 - OK
prometheus-exporter-1  | 2025-07-02 01:53:39,772 - prometheus-prefect-exporter - [INFO] Pagination is enabled
prometheus-exporter-1  | 2025-07-02 01:53:39,772 - prometheus-prefect-exporter - [INFO] Pagination limit is 200
prometheus-exporter-1  | 2025-07-02 01:53:39,772 - prometheus-prefect-exporter - [INFO] Initializing metrics...
prometheus-exporter-1  | 2025-07-02 01:53:39,772 - prometheus-prefect-exporter - [INFO] CSRF Token is expired or has not been generated yet. Fetching new CSRF Token...
prometheus-exporter-1  | 2025-07-02 01:53:39,820 - prometheus-prefect-exporter - [INFO] Exporter listening on 0.0.0.0:8000

$ curl -s http://localhost:8000 | head -n 5
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 1668.0
python_gc_objects_collected_total{generation="1"} 223.0
python_gc_objects_collected_total{generation="2"} 0.0
```

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review
