### PR TITLE
refactor: remove high-cardinality labels

### DIFF
--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -148,7 +148,6 @@ class PrefectMetrics(object):
             "prefect_info_deployment",
             "Prefect deployment info",
             labels=[
-                "created",
                 "flow_name",
                 "is_schedule_active",
                 "deployment_name",
@@ -190,7 +189,6 @@ class PrefectMetrics(object):
 
             prefect_info_deployments.add_metric(
                 [
-                    str(deployment.get("created", "null")),
                     str(flow_name),
                     str(is_schedule_active),
                     str(deployment.get("name", "null")),
@@ -221,13 +219,12 @@ class PrefectMetrics(object):
         prefect_info_flows = GaugeMetricFamily(
             "prefect_info_flows",
             "Prefect flow info",
-            labels=["created", "flow_name"],
+            labels=["flow_name"],
         )
 
         for flow in flows:
             prefect_info_flows.add_metric(
                 [
-                    str(flow.get("created", "null")),
                     str(flow.get("name", "null")),
                 ],
                 1,
@@ -295,7 +292,6 @@ class PrefectMetrics(object):
             "prefect_info_flow_runs",
             "Prefect flow runs info",
             labels=[
-                "created",
                 "deployment_name",
                 "end_time",
                 "flow_name",
@@ -338,7 +334,6 @@ class PrefectMetrics(object):
             state = 0 if flow_run.get("state_name") != "Running" else 1
             prefect_info_flow_runs.add_metric(
                 [
-                    str(flow_run.get("created", "null")),
                     str(deployment_name),
                     str(flow_run.get("end_time", "null")),
                     str(flow_name),
@@ -370,7 +365,6 @@ class PrefectMetrics(object):
             "prefect_info_work_pools",
             "Prefect work pools info",
             labels=[
-                "created",
                 "is_paused",
                 "work_pool_name",
                 "type",
@@ -382,7 +376,6 @@ class PrefectMetrics(object):
             state = 0 if work_pool.get("is_paused") else 1
             prefect_info_work_pools.add_metric(
                 [
-                    str(work_pool.get("created", "null")),
                     str(work_pool.get("is_paused", "null")),
                     str(work_pool.get("name", "null")),
                     str(work_pool.get("type", "null")),
@@ -409,7 +402,6 @@ class PrefectMetrics(object):
             "prefect_info_work_queues",
             "Prefect work queues info",
             labels=[
-                "created",
                 "is_paused",
                 "work_queue_name",
                 "priority",
@@ -430,7 +422,6 @@ class PrefectMetrics(object):
             health_check_policy = status_info.get("health_check_policy", {})
             prefect_info_work_queues.add_metric(
                 [
-                    str(work_queue.get("created", "null")),
                     str(work_queue.get("is_paused", "null")),
                     str(work_queue.get("name", "null")),
                     str(work_queue.get("priority", "null")),

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -192,7 +192,6 @@ class PrefectMetrics(object):
                 [
                     str(deployment.get("created", "null")),
                     str(flow_name),
-                    str(deployment.get("id", "null")),
                     str(is_schedule_active),
                     str(deployment.get("name", "null")),
                     str(deployment.get("path", "null")),
@@ -229,7 +228,6 @@ class PrefectMetrics(object):
             prefect_info_flows.add_metric(
                 [
                     str(flow.get("created", "null")),
-                    str(flow.get("id", "null")),
                     str(flow.get("name", "null")),
                 ],
                 1,
@@ -301,11 +299,9 @@ class PrefectMetrics(object):
                 "deployment_name",
                 "end_time",
                 "flow_name",
-                "flow_run_id",
                 "flow_run_name",
                 "run_count",
                 "start_time",
-                "state_id",
                 "state_name",
                 "total_run_time",
                 "work_queue_name",
@@ -347,11 +343,9 @@ class PrefectMetrics(object):
                     str(deployment_name),
                     str(flow_run.get("end_time", "null")),
                     str(flow_name),
-                    str(flow_run.get("id", "null")),
                     str(flow_run.get("name", "null")),
                     str(flow_run.get("run_count", "null")),
                     str(flow_run.get("start_time", "null")),
-                    str(flow_run.get("state_id", "null")),
                     str(flow_run.get("state_name", "null")),
                     str(flow_run.get("total_run_time", "null")),
                     str(flow_run.get("work_queue_name", "null")),
@@ -378,8 +372,6 @@ class PrefectMetrics(object):
             "Prefect work pools info",
             labels=[
                 "created",
-                "work_queue_id",
-                "work_pool_id",
                 "is_paused",
                 "work_pool_name",
                 "type",
@@ -392,8 +384,6 @@ class PrefectMetrics(object):
             prefect_info_work_pools.add_metric(
                 [
                     str(work_pool.get("created", "null")),
-                    str(work_pool.get("default_queue_id", "null")),
-                    str(work_pool.get("id", "null")),
                     str(work_pool.get("is_paused", "null")),
                     str(work_pool.get("name", "null")),
                     str(work_pool.get("type", "null")),
@@ -421,12 +411,10 @@ class PrefectMetrics(object):
             "Prefect work queues info",
             labels=[
                 "created",
-                "work_queue_id",
                 "is_paused",
                 "work_queue_name",
                 "priority",
                 "type",
-                "work_pool_id",
                 "work_pool_name",
                 "status",
                 "healthy",
@@ -444,12 +432,10 @@ class PrefectMetrics(object):
             prefect_info_work_queues.add_metric(
                 [
                     str(work_queue.get("created", "null")),
-                    str(work_queue.get("id", "null")),
                     str(work_queue.get("is_paused", "null")),
                     str(work_queue.get("name", "null")),
                     str(work_queue.get("priority", "null")),
                     str(work_queue.get("type", "null")),
-                    str(work_queue.get("work_pool_id", "null")),
                     str(work_queue.get("work_pool_name", "null")),
                     str(work_queue.get("status", "null")),
                     str(status_info.get("healthy", "null")),

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -250,7 +250,7 @@ class PrefectMetrics(object):
         prefect_flow_runs_total_run_time = CounterMetricFamily(
             "prefect_flow_runs_total_run_time",
             "Prefect flow-run total run time in seconds",
-            labels=["flow_name", "flow_run_name"],
+            labels=["flow_name"],
         )
 
         for flow_run in all_flow_runs:
@@ -299,7 +299,6 @@ class PrefectMetrics(object):
                 "deployment_name",
                 "end_time",
                 "flow_name",
-                "flow_run_name",
                 "run_count",
                 "start_time",
                 "state_name",

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -149,7 +149,6 @@ class PrefectMetrics(object):
             "Prefect deployment info",
             labels=[
                 "created",
-                "flow_id",
                 "flow_name",
                 "is_schedule_active",
                 "deployment_name",
@@ -192,7 +191,6 @@ class PrefectMetrics(object):
             prefect_info_deployments.add_metric(
                 [
                     str(deployment.get("created", "null")),
-                    str(deployment.get("flow_id", "null")),
                     str(flow_name),
                     str(deployment.get("id", "null")),
                     str(is_schedule_active),
@@ -224,7 +222,7 @@ class PrefectMetrics(object):
         prefect_info_flows = GaugeMetricFamily(
             "prefect_info_flows",
             "Prefect flow info",
-            labels=["created", "flow_id", "flow_name"],
+            labels=["created", "flow_name"],
         )
 
         for flow in flows:
@@ -254,7 +252,7 @@ class PrefectMetrics(object):
         prefect_flow_runs_total_run_time = CounterMetricFamily(
             "prefect_flow_runs_total_run_time",
             "Prefect flow-run total run time in seconds",
-            labels=["flow_id", "flow_name", "flow_run_name"],
+            labels=["flow_name", "flow_run_name"],
         )
 
         for flow_run in all_flow_runs:
@@ -286,7 +284,6 @@ class PrefectMetrics(object):
 
             prefect_flow_runs_total_run_time.add_metric(
                 [
-                    str(flow_run.get("flow_id", "null")),
                     str(flow_name),
                     str(flow_run.get("name", "null")),
                 ],
@@ -303,7 +300,6 @@ class PrefectMetrics(object):
                 "created",
                 "deployment_name",
                 "end_time",
-                "flow_id",
                 "flow_name",
                 "flow_run_id",
                 "flow_run_name",
@@ -350,7 +346,6 @@ class PrefectMetrics(object):
                     str(flow_run.get("created", "null")),
                     str(deployment_name),
                     str(flow_run.get("end_time", "null")),
-                    str(flow_run.get("flow_id", "null")),
                     str(flow_name),
                     str(flow_run.get("id", "null")),
                     str(flow_run.get("name", "null")),

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -151,7 +151,6 @@ class PrefectMetrics(object):
                 "created",
                 "flow_id",
                 "flow_name",
-                "deployment_id",
                 "is_schedule_active",
                 "deployment_name",
                 "path",
@@ -302,7 +301,6 @@ class PrefectMetrics(object):
             "Prefect flow runs info",
             labels=[
                 "created",
-                "deployment_id",
                 "deployment_name",
                 "end_time",
                 "flow_id",
@@ -350,7 +348,6 @@ class PrefectMetrics(object):
             prefect_info_flow_runs.add_metric(
                 [
                     str(flow_run.get("created", "null")),
-                    str(flow_run.get("deployment_id", "null")),
                     str(deployment_name),
                     str(flow_run.get("end_time", "null")),
                     str(flow_run.get("flow_id", "null")),


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

Related to https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/84

Removes high-cardinality labels from metrics:
- resource UUIDs
- `flow_run_name` values
- `created` timestamps

Here's an example of some metrics with the changes:

```
$ curl -s http://localhost:8000 | grep '^prefect_'
prefect_deployments_total 1.0
prefect_info_deployment{deployment_name="Hello World - Mitch",flow_name="hello-world",is_schedule_active="True",path=".",paused="False",status="READY",tags="",work_pool_name="None",work_queue_name="None"} 1.0
prefect_flows_total 1.0
prefect_info_flows{flow_name="hello-world"} 1.0
prefect_flow_runs_total 0.0
prefect_work_pools_total 1.0
prefect_info_work_pools{is_paused="False",status="READY",type="docker",work_pool_name="local"} 1.0
prefect_work_queues_total 1.0
prefect_info_work_queues{health_check_policy_maximum_late_runs="0",health_check_policy_maximum_seconds_since_last_polled="60",healthy="True",is_paused="False",last_polled="2025-07-22T21:38:46.069664Z",late_runs_count="0",priority="1",status="READY",type="null",work_pool_name="local",work_queue_name="default"} 1.0
```

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review
