### PR TITLE
docs: clarify pagination settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_API_KEY` | Prefect API key (Optional) | `""` |
 | `PREFECT_API_AUTH_STRING` | Prefect API auth string, automatically base64-encoded (Optional) | `""` |
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
-| `PAGINATION_ENABLED` | Enable pagination usage. (Uses more resources) | `True` |
-| `PAGINATION_LIMIT` | Pagination limit | `200` |
+| `PAGINATION_ENABLED` | Enable pagination for API requests. Can help reduce server load and avoid timeouts. Can be disabled on very small instances. | `True` |
+| `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
 
 
 ## Contributing


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

- Provides more detail for the pagination settings.
- Reduces the default pagination limit to `100` (open to feedback on this - the aim is to provide a safer default for large instances to avoid OOMs in the first place).

Closes https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/83

Follow-up to https://github.com/PrefectHQ/prometheus-prefect-exporter/pull/48

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [ ] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review
