### PR TITLE
feat: add prefect_deployment_failed_flow_runs metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
 | `PAGINATION_ENABLED` | Enable pagination for API requests. Can help reduce server load and avoid timeouts. Can be disabled on very small instances. | `True` |
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
-| `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. | `10080` (7 days) |
+| `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. Set to `0` to disable the metric entirely. | `10080` (7 days) |
 | `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_failed_flow_runs`. | `10` |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
 | `PAGINATION_ENABLED` | Enable pagination for API requests. Can help reduce server load and avoid timeouts. Can be disabled on very small instances. | `True` |
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
+| `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_last_failed_flow_run` metric. Failed runs older than this window are ignored. | `10080` (7 days) |
+| `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_last_failed_flow_run`. | `10` |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ You can modify environment variables to change the behavior of the exporter.
 | `PREFECT_CSRF_ENABLED` | Enable compatibilty with Prefect Servers using CSRF protection | `False` |
 | `PAGINATION_ENABLED` | Enable pagination for API requests. Can help reduce server load and avoid timeouts. Can be disabled on very small instances. | `True` |
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
-| `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_last_failed_flow_run` metric. Failed runs older than this window are ignored. | `10080` (7 days) |
-| `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_last_failed_flow_run`. | `10` |
+| `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. | `10080` (7 days) |
+| `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_failed_flow_runs`. | `10` |
 
 ## Contributing
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ def metrics():
     metrics_addr = os.getenv("METRICS_ADDR", "0.0.0.0")
     metrics_port = int(os.getenv("METRICS_PORT", "8000"))
     offset_minutes = int(os.getenv("OFFSET_MINUTES", "3"))
+    failed_runs_offset_minutes = int(os.getenv("FAILED_RUNS_OFFSET_MINUTES", "10080"))  # 7 days
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     api_auth_string = str(os.getenv("PREFECT_API_AUTH_STRING", ""))
@@ -63,6 +64,7 @@ def metrics():
         url=url,
         headers=headers,
         offset_minutes=offset_minutes,
+        failed_runs_offset_minutes=failed_runs_offset_minutes,
         max_retries=max_retries,
         client_id=csrf_client_id,
         csrf_enabled=str(os.getenv("PREFECT_CSRF_ENABLED", "False")) == "True",

--- a/main.py
+++ b/main.py
@@ -20,7 +20,9 @@ def metrics():
     metrics_addr = os.getenv("METRICS_ADDR", "0.0.0.0")
     metrics_port = int(os.getenv("METRICS_PORT", "8000"))
     offset_minutes = int(os.getenv("OFFSET_MINUTES", "3"))
-    failed_runs_offset_minutes = int(os.getenv("FAILED_RUNS_OFFSET_MINUTES", "10080"))  # 7 days
+    failed_runs_offset_minutes = int(
+        os.getenv("FAILED_RUNS_OFFSET_MINUTES", "10080")
+    )  # 7 days
     failed_runs_limit = int(os.getenv("FAILED_RUNS_LIMIT", "10"))
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
@@ -36,7 +38,9 @@ def metrics():
     headers = {"accept": "application/json", "Content-Type": "application/json"}
 
     if api_auth_string:
-        api_auth_string_encoded = base64.b64encode(api_auth_string.encode("utf-8")).decode("utf-8")
+        api_auth_string_encoded = base64.b64encode(
+            api_auth_string.encode("utf-8")
+        ).decode("utf-8")
         headers["Authorization"] = f"Basic {api_auth_string_encoded}"
         logger.info("Added Basic Authorization header for PREFECT_API_AUTH_STRING")
 

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def metrics():
     metrics_port = int(os.getenv("METRICS_PORT", "8000"))
     offset_minutes = int(os.getenv("OFFSET_MINUTES", "3"))
     failed_runs_offset_minutes = int(os.getenv("FAILED_RUNS_OFFSET_MINUTES", "10080"))  # 7 days
+    failed_runs_limit = int(os.getenv("FAILED_RUNS_LIMIT", "10"))
     url = str(os.getenv("PREFECT_API_URL", "http://localhost:4200/api"))
     api_key = str(os.getenv("PREFECT_API_KEY", ""))
     api_auth_string = str(os.getenv("PREFECT_API_AUTH_STRING", ""))
@@ -65,6 +66,7 @@ def metrics():
         headers=headers,
         offset_minutes=offset_minutes,
         failed_runs_offset_minutes=failed_runs_offset_minutes,
+        failed_runs_limit=failed_runs_limit,
         max_retries=max_retries,
         client_id=csrf_client_id,
         csrf_enabled=str(os.getenv("PREFECT_CSRF_ENABLED", "False")) == "True",

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -81,3 +81,23 @@ class PrefectFlowRuns(PrefectApiMetric):
         )
 
         return all_flow_runs
+
+    def get_failed_flow_runs_info(self) -> list:
+        """
+        Get all flow runs in a FAILED state within the FAILED_RUNS_OFFSET_MINUTES window.
+
+        Returns:
+            list: JSON response containing failed flow runs information.
+        """
+        failed_flow_runs = self._get_with_pagination(
+            base_data={
+                "flow_runs": {
+                    "operator": "and_",
+                    "state": {"type": {"any_": ["FAILED"]}},
+                    "start_time": {"after_": f"{self.after_data_fmt}"},
+                    "deployment_id": {"is_null_": False},
+                }
+            }
+        )
+
+        return failed_flow_runs

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -122,15 +122,18 @@ class PrefectMetrics(object):
             self.enable_pagination,
             self.pagination_limit,
         ).get_all_flow_runs_info()
-        failed_flow_runs = PrefectFlowRuns(
-            self.url,
-            self.headers,
-            self.max_retries,
-            self.failed_runs_offset_minutes,
-            self.logger,
-            self.enable_pagination,
-            self.pagination_limit,
-        ).get_failed_flow_runs_info(limit=self.failed_runs_limit)
+        if self.failed_runs_offset_minutes == 0:
+            failed_flow_runs = {}
+        else:
+            failed_flow_runs = PrefectFlowRuns(
+                self.url,
+                self.headers,
+                self.max_retries,
+                self.failed_runs_offset_minutes,
+                self.logger,
+                self.enable_pagination,
+                self.pagination_limit,
+            ).get_failed_flow_runs_info(limit=self.failed_runs_limit)
         work_pools = PrefectWorkPools(
             self.url,
             self.headers,

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -357,9 +357,9 @@ class PrefectMetrics(object):
 
         yield prefect_info_flow_runs
 
-        # prefect_deployment_last_failed_flow_run metric
-        prefect_deployment_last_failed_flow_run = GaugeMetricFamily(
-            "prefect_deployment_last_failed_flow_run",
+        # prefect_deployment_failed_flow_runs metric
+        prefect_deployment_failed_flow_runs = GaugeMetricFamily(
+            "prefect_deployment_failed_flow_runs",
             "Last failed flow run ID per deployment within the FAILED_RUNS_OFFSET_MINUTES window",
             labels=["deployment_name", "flow_name", "last_failed_run_id"],
         )
@@ -371,11 +371,11 @@ class PrefectMetrics(object):
             deployment_name = deployments_by_id.get(deployment_id, "null")
             flow_name = flows_by_id.get(flow_id, "null")
             for run_id in run_ids:
-                prefect_deployment_last_failed_flow_run.add_metric(
+                prefect_deployment_failed_flow_runs.add_metric(
                     [deployment_name, flow_name, run_id], 1
                 )
 
-        yield prefect_deployment_last_failed_flow_run
+        yield prefect_deployment_failed_flow_runs
 
         ##
         # PREFECT WORK POOLS METRICS


### PR DESCRIPTION
### Summary

Adds `prefect_deployment_failed_flow_runs` - a metric to track unresolved failed runs per deployment.

#### Why

When an ETL pipeline's run fails, the ideal correct resolutions are:
* fix the issue and restart it, 
* or explicitly delete it. 

This is the pipeline completeness principle — every scheduled run is expected to produce output.

The existing `prefect_info_flow_runs` metric uses a short sliding window (`OFFSET_MINUTES`, default 3 min). A failed run from 2 hours ago quietly disappears from the metric, the alert auto-resolves, and the failure goes unnoticed, even though nothing was actually fixed.

The new metric tracks failed runs over a 7-day window (configurable via `FAILED_RUNS_OFFSET_MINUTES`). A run only drops from the metric when it's actually resolved, either the state is changed to Success or the run is deleted.

Since each failed run is exposed as its own time series with the run ID as a label, you get one alert per unresolved failure. As you fix runs one by one, their alerts resolve. New failures are added to the set as they appear. You're always looking at the full backlog, not just the latest.

#### Note on cardinality

This metric intentionally uses `last_failed_run_id` (a UUID) as a label, which #85 explicitly removed from other metrics. However, the total number of active time series here is bounded: `FAILED_RUNS_LIMIT × number_of_deployments`. With defaults of 10 runs and a typical deployment count, this is predictable and small.

#### New environment variables

`FAILED_RUNS_OFFSET_MINUTES` (default: 10080, 7 days) — lookback window
`FAILED_RUNS_LIMIT` (default: 10) — max failed runs exposed per deployment, keeping cardinality in check

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review