### PR TITLE
feat: include crashed in failed_flow_runs

### DIFF
--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -91,13 +91,13 @@ class PrefectFlowRuns(PrefectApiMetric):
             limit (int): Maximum number of recent failed runs to return per deployment/flow pair.
 
         Returns:
-            dict: Mapping of (deployment_id, flow_id) -> [run_id, ...]
+            dict: Mapping of (deployment_id, flow_id, state_name) -> [run_id, ...]
         """
         all_failed = self._get_with_pagination(
             base_data={
                 "flow_runs": {
                     "operator": "and_",
-                    "state": {"type": {"any_": ["FAILED"]}},
+                    "state": {"type": {"any_": ["FAILED", "CRASHED"]}},
                     "start_time": {"after_": f"{self.after_data_fmt}"},
                     "deployment_id": {"is_null_": False},
                 },
@@ -107,7 +107,11 @@ class PrefectFlowRuns(PrefectApiMetric):
 
         result = defaultdict(list)
         for flow_run in all_failed:
-            key = (flow_run.get("deployment_id"), flow_run.get("flow_id"))
+            key = (
+                flow_run.get("deployment_id"),
+                flow_run.get("flow_id"),
+                flow_run.get("state_name"),
+            )
             if len(result[key]) < limit:
                 result[key].append(str(flow_run.get("id", "null")))
 

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -374,19 +374,19 @@ class PrefectMetrics(object):
         # prefect_deployment_failed_flow_runs metric
         prefect_deployment_failed_flow_runs = GaugeMetricFamily(
             "prefect_deployment_failed_flow_runs",
-            "Last failed flow run ID per deployment within the FAILED_RUNS_OFFSET_MINUTES window",
-            labels=["deployment_name", "flow_name", "last_failed_run_id"],
+            "Last failed or crashed flow run ID per deployment within the FAILED_RUNS_OFFSET_MINUTES window",
+            labels=["deployment_name", "flow_name", "last_failed_run_id", "state_name"],
         )
 
         deployments_by_id = {d["id"]: d["name"] for d in deployments if d.get("id")}
         flows_by_id = {f["id"]: f["name"] for f in flows if f.get("id")}
 
-        for (deployment_id, flow_id), run_ids in failed_flow_runs.items():
+        for (deployment_id, flow_id, state_name), run_ids in failed_flow_runs.items():
             deployment_name = deployments_by_id.get(deployment_id, "null")
             flow_name = flows_by_id.get(flow_id, "null")
             for run_id in run_ids:
                 prefect_deployment_failed_flow_runs.add_metric(
-                    [deployment_name, flow_name, run_id], 1
+                    [deployment_name, flow_name, run_id, state_name], 1
                 )
 
         yield prefect_deployment_failed_flow_runs


### PR DESCRIPTION
### Summary

  - Include CRASHED flow runs alongside FAILED in the prefect_deployment_failed_flow_runs metric
  - Add a state_name label to the metric to distinguish between Failed and Crashed runs   

Following the discussion about including Crashed alongside Failed runs : https://github.com/PrefectHQ/prometheus-prefect-exporter/pull/117#issuecomment-3971468087

example : 
```
prefect_deployment_failed_flow_runs{deployment_name="xxx",flow_name="xxx",last_failed_run_id="xxx",state_name="Failed"} 1.0
prefect_deployment_failed_flow_runs{deployment_name="xxx",flow_name="xxx",last_failed_run_id="xxx",state_name="Crashed"} 1.0
``` 

### Requirements

- [ ] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review