### PR TITLE
feat: add opt-in flow_run_name label to prefect_info_flow_runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
 | `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. Set to `0` to disable the metric entirely. | `10080` (7 days) |
 | `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_failed_flow_runs`. | `10` |
-| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs`. Increases cardinality proportional to concurrent flow runs. | `False` |
+| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs`. Increases cardinality proportional to the number of concurrent flow runs within the `OFFSET_MINUTES` window, not total historical runs. Series go stale once runs fall outside the window. | `False` |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
 | `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. Set to `0` to disable the metric entirely. | `10080` (7 days) |
 | `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_failed_flow_runs`. | `10` |
+| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs`. Increases cardinality proportional to concurrent flow runs. | `False` |
 
 ## Contributing
 

--- a/compose.yml
+++ b/compose.yml
@@ -29,6 +29,7 @@ services:
       PREFECT_API_URL: http://prefect:4200/api
       # PREFECT_API_AUTH_STRING: ""
       # PREFECT_CSRF_ENABLED: "True"
+      # ENABLE_FLOW_RUN_NAME_LABEL: "True"
     depends_on:
       prefect:
         condition: service_healthy

--- a/main.py
+++ b/main.py
@@ -58,11 +58,17 @@ def metrics():
     #
     enable_pagination = str(os.getenv("PAGINATION_ENABLED", "True")) == "True"
     pagination_limit = int(os.getenv("PAGINATION_LIMIT", 200))
+    enable_flow_run_name_label = (
+        str(os.getenv("ENABLE_FLOW_RUN_NAME_LABEL", "False")) == "True"
+    )
     if enable_pagination:
         logger.info("Pagination is enabled")
         logger.info(f"Pagination limit is {pagination_limit}")
     else:
         logger.info("Pagination is disabled")
+
+    if enable_flow_run_name_label:
+        logger.info("Flow run name label is enabled on prefect_info_flow_runs")
 
     # Create an instance of the PrefectMetrics class
     metrics = PrefectMetrics(
@@ -78,6 +84,7 @@ def metrics():
         # Enable pagination if not specified to avoid breaking existing deployments
         enable_pagination=enable_pagination,
         pagination_limit=pagination_limit,
+        enable_flow_run_name_label=enable_flow_run_name_label,
     )
 
     # Register the metrics with Prometheus

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -313,6 +313,7 @@ class PrefectMetrics(object):
             prefect_flow_runs_total_run_time.add_metric(
                 [
                     str(flow_name),
+                    str(flow_run.get("name", "null")),
                 ],
                 flow_run.get("total_run_time", "null"),
             )

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -31,6 +31,7 @@ class PrefectMetrics(object):
         logger,
         enable_pagination,
         pagination_limit,
+        enable_flow_run_name_label=False,
     ) -> None:
         """
         Initialize the PrefectMetrics instance.
@@ -47,6 +48,7 @@ class PrefectMetrics(object):
             client_id (str): The client ID for CSRF.
             enable_pagination (bool): Whether pagination is enabled.
             pagination_limit (int): The pagination limit.
+            enable_flow_run_name_label (bool): Whether to include flow_run_name in prefect_info_flow_runs.
         """
 
         self.headers = headers
@@ -60,6 +62,7 @@ class PrefectMetrics(object):
         self.csrf_enabled = csrf_enabled
         self.enable_pagination = enable_pagination
         self.pagination_limit = pagination_limit
+        self.enable_flow_run_name_label = enable_flow_run_name_label
         self.csrf_token = None
         self.csrf_token_expiration = None
 
@@ -310,7 +313,6 @@ class PrefectMetrics(object):
             prefect_flow_runs_total_run_time.add_metric(
                 [
                     str(flow_name),
-                    str(flow_run.get("name", "null")),
                 ],
                 flow_run.get("total_run_time", "null"),
             )
@@ -318,15 +320,19 @@ class PrefectMetrics(object):
         yield prefect_flow_runs_total_run_time
 
         # prefect_info_flow_runs metric
+        info_flow_runs_labels = [
+            "deployment_name",
+            "flow_name",
+            "state_name",
+            "work_queue_name",
+        ]
+        if self.enable_flow_run_name_label:
+            info_flow_runs_labels.append("flow_run_name")
+
         prefect_info_flow_runs = GaugeMetricFamily(
             "prefect_info_flow_runs",
             "Prefect flow runs info",
-            labels=[
-                "deployment_name",
-                "flow_name",
-                "state_name",
-                "work_queue_name",
-            ],
+            labels=info_flow_runs_labels,
         )
 
         state_counts = defaultdict(int)
@@ -364,6 +370,8 @@ class PrefectMetrics(object):
                 str(flow_run.get("state_name", "null")),
                 str(flow_run.get("work_queue_name", "null")),
             )
+            if self.enable_flow_run_name_label:
+                label_key += (str(flow_run.get("name", "null")),)
             state_counts[label_key] += 1
 
         for label_key, count in state_counts.items():


### PR DESCRIPTION
### Summary

A customer needed to distinguish concurrent runs of the same flow when intervals are short. The Prefect UI shows per-run names, but without `flow_run_name` in the metrics there's no way to correlate state changes to specific runs.

This adds an `ENABLE_FLOW_RUN_NAME_LABEL` env var (default `False`) that appends `flow_run_name` to `prefect_info_flow_runs` when enabled. Cardinality is bounded by the `OFFSET_MINUTES` scrape window (default 3 min), not historical runs, so it scales with concurrency rather than accumulating over time. Similar pattern to how `kube_pod_info` handles ephemeral entities.

Related to https://linear.app/prefect/issue/PLA-2635

### Testing

#### Without feature enabled

```
$ curl -s localhost:8000 | grep prefect_info_flow_runs
# HELP prefect_info_flow_runs Prefect flow runs info
# TYPE prefect_info_flow_runs gauge
prefect_info_flow_runs{deployment_name="null",flow_name="my-flow",state_name="Completed",work_queue_name="None"} 3.0
```
No flow_run_name label.

#### With feature enabled

Set ENABLE_FLOW_RUN_NAME_LABEL: "True" in compose.yml:

```
$ curl -s localhost:8000 | grep prefect_info_flow_runs
# HELP prefect_info_flow_runs Prefect flow runs info
# TYPE prefect_info_flow_runs gauge
prefect_info_flow_runs{deployment_name="null",flow_name="my-flow",flow_run_name="graceful-mouse",state_name="Completed",work_queue_name="None"} 1.0
prefect_info_flow_runs{deployment_name="null",flow_name="my-flow",flow_run_name="thistle-phoenix",state_name="Completed",work_queue_name="None"} 1.0
prefect_info_flow_runs{deployment_name="null",flow_name="my-flow",flow_run_name="mauve-mantis",state_name="Completed",work_queue_name="None"} 1.0
```

-----

<details>
<summary>Session context</summary>

Started from a customer request to match state changes to specific flow runs when multiple runs overlap. Investigated git history and confirmed `flow_run_name` was deliberately removed in #85 for cardinality reasons. Analyzed the scrape window bounds and concluded cardinality is safe since it's proportional to concurrent runs within OFFSET_MINUTES, not all-time history. Opted for a config flag (default off) to keep the default behavior conservative.
</details>