### PR TITLE
fix: remove extra value in prefect_flow_runs_total_run_time add_metric

### DIFF
--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -310,7 +310,6 @@ class PrefectMetrics(object):
             prefect_flow_runs_total_run_time.add_metric(
                 [
                     str(flow_name),
-                    str(flow_run.get("name", "null")),
                 ],
                 flow_run.get("total_run_time", "null"),
             )


### PR DESCRIPTION
### Summary

`prefect_flow_runs_total_run_time` declares labels as `["flow_name"]` but `add_metric` was passing two values (`flow_name` + `flow_run_name`). This mismatch was introduced when #87 partially reverted the high-cardinality label removal from #85.

Removes the extra `flow_run.get("name", "null")` value so it matches the declared labels.

<details>
<summary>Session context</summary>

Discovered this while investigating whether to add flow_run_name back to prefect_info_flow_runs. The bug was introduced in #87 which tried to re-add flow_run_name but only added the value, not the label declaration.
</details>