### PR TITLE
feat: add running flow runs metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
 | `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. Set to `0` to disable the metric entirely. | `10080` (7 days) |
 | `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_failed_flow_runs`. | `10` |
-| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs`. Increases cardinality proportional to the number of concurrent flow runs within the `OFFSET_MINUTES` window, not total historical runs. Series go stale once runs fall outside the window. | `False` |
+| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs` and `prefect_flow_runs_ongoing_run_time`. Increases cardinality proportional to the number of concurrent flow runs within the `OFFSET_MINUTES` window, not total historical runs. Series go stale once runs fall outside the window. | `False` |
 
 ## Contributing
 

--- a/main.py
+++ b/main.py
@@ -68,7 +68,9 @@ def metrics():
         logger.info("Pagination is disabled")
 
     if enable_flow_run_name_label:
-        logger.info("Flow run name label is enabled on prefect_info_flow_runs")
+        logger.info(
+            "Flow run name label is enabled on prefect_info_flow_runs and prefect_flow_runs_ongoing_run_time"
+        )
 
     # Create an instance of the PrefectMetrics class
     metrics = PrefectMetrics(

--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -83,6 +83,25 @@ class PrefectFlowRuns(PrefectApiMetric):
 
         return all_flow_runs
 
+    def get_ongoing_flow_runs_info(self) -> list:
+        """
+        Get information about ongoing flow runs
+
+        Returns:
+            dict: JSON response containing ongoing flow runs information.
+        """
+        ongoing_flow_runs = self._get_with_pagination(
+            base_data={
+                "flow_runs": {
+                    "operator": "and_",
+                    "end_time": {"is_null_": True},
+                    "state": {"type": {"any_": ["RUNNING", "PENDING", "SCHEDULED"]}},
+                }
+            }
+        )
+
+        return ongoing_flow_runs
+
     def get_failed_flow_runs_info(self, limit: int) -> dict:
         """
         Get the last N failed flow runs per (deployment_id, flow_id) pair within the window.

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -48,7 +48,7 @@ class PrefectMetrics(object):
             client_id (str): The client ID for CSRF.
             enable_pagination (bool): Whether pagination is enabled.
             pagination_limit (int): The pagination limit.
-            enable_flow_run_name_label (bool): Whether to include flow_run_name in prefect_info_flow_runs.
+            enable_flow_run_name_label (bool): Whether to include flow_run_name in prefect_info_flow_runs and prefect_flow_runs_ongoing_run_time.
         """
 
         self.headers = headers
@@ -136,6 +136,15 @@ class PrefectMetrics(object):
             self.enable_pagination,
             self.pagination_limit,
         ).get_all_flow_runs_info()
+        ongoing_flow_runs = PrefectFlowRuns(
+            self.url,
+            self.headers,
+            self.max_retries,
+            self.offset_minutes,
+            self.logger,
+            self.enable_pagination,
+            self.pagination_limit,
+        ).get_ongoing_flow_runs_info()
         if self.failed_runs_offset_minutes == 0:
             failed_flow_runs = {}
         else:
@@ -318,6 +327,71 @@ class PrefectMetrics(object):
             )
 
         yield prefect_flow_runs_total_run_time
+
+        prefect_flow_run_ongoing_labels = [
+            "deployment_name",
+            "flow_name",
+            "state_name",
+        ]
+
+        if self.enable_flow_run_name_label:
+            prefect_flow_run_ongoing_labels.append("flow_run_name")
+
+        prefect_flow_runs_ongoing_run_time = GaugeMetricFamily(
+            "prefect_flow_runs_ongoing_run_time",
+            "Prefect flow runs ongoing run time in seconds",
+            labels=prefect_flow_run_ongoing_labels,
+        )
+
+        current_time = datetime.now(timezone.utc)
+
+        for flow_run in ongoing_flow_runs:
+            if flow_run.get("deployment_id") is None:
+                deployment_name = "null"
+            else:
+                deployment_name = next(
+                    (
+                        deployment.get("name")
+                        for deployment in deployments
+                        if flow_run.get("deployment_id") == deployment.get("id")
+                    ),
+                    "null",
+                )
+
+            # get flow name
+            if flow_run.get("flow_id") is None:
+                flow_name = "null"
+            else:
+                flow_name = next(
+                    (
+                        flow.get("name")
+                        for flow in flows
+                        if flow.get("id") == flow_run.get("flow_id")
+                    ),
+                    "null",
+                )
+
+            label_keys = [
+                str(deployment_name),
+                str(flow_name),
+                str(flow_run.get("state_name")),
+            ]
+            if self.enable_flow_run_name_label:
+                label_keys.append(str(flow_run.get("name", "null")))
+
+            start_time = (
+                datetime.fromisoformat(flow_run.get("start_time"))
+                if flow_run.get("start_time")
+                else current_time
+            )
+            run_time = current_time - start_time
+
+            prefect_flow_runs_ongoing_run_time.add_metric(
+                label_keys,
+                run_time.total_seconds(),
+            )
+
+        yield prefect_flow_runs_ongoing_run_time
 
         # prefect_info_flow_runs metric
         info_flow_runs_labels = [


### PR DESCRIPTION
### Summary

`prefect_flow_runs_total_run_time` only returns completed run times.

The idea is to have metrics about running flows as well.

Related to https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/129

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review
