### PR TITLE
feat: honor Retry-After header for 429/503 responses

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,36 @@
+---
+name: Tests
+
+"on":
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: pytest

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -70,11 +70,11 @@ class PrefectApiMetric:
                     resp.raise_for_status()
                     break
                 except requests.exceptions.RequestException as err:
-                    self.logger.error(err)
                     signal = detect_retry_after(err.response)
                     if signal is not None:
                         log_retry_after(self.logger, endpoint, signal)
                         return all_items
+                    self.logger.error(err)
                     if retry < self.max_retries - 1:
                         time.sleep(2**retry)
                     else:

--- a/metrics/api_metric.py
+++ b/metrics/api_metric.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 import requests
 
+from metrics.retry_after import detect_retry_after, log_retry_after
+
 
 class PrefectApiMetric:
     """
@@ -69,6 +71,10 @@ class PrefectApiMetric:
                     break
                 except requests.exceptions.RequestException as err:
                     self.logger.error(err)
+                    signal = detect_retry_after(err.response)
+                    if signal is not None:
+                        log_retry_after(self.logger, endpoint, signal)
+                        return all_items
                     if retry < self.max_retries - 1:
                         time.sleep(2**retry)
                     else:

--- a/metrics/healthz.py
+++ b/metrics/healthz.py
@@ -1,6 +1,8 @@
 import requests
 import time
 
+from metrics.retry_after import detect_retry_after, log_retry_after
+
 
 class PrefectHealthz:
     """
@@ -45,6 +47,10 @@ class PrefectHealthz:
                 break
             except requests.exceptions.RequestException as err:
                 self.logger.error(err)
+                signal = detect_retry_after(err.response)
+                if signal is not None:
+                    log_retry_after(self.logger, endpoint, signal)
+                    raise SystemExit(err)
                 if retry < self.max_retries - 1:
                     time.sleep(2**retry)
                 else:

--- a/metrics/healthz.py
+++ b/metrics/healthz.py
@@ -46,11 +46,11 @@ class PrefectHealthz:
                 )
                 break
             except requests.exceptions.RequestException as err:
-                self.logger.error(err)
                 signal = detect_retry_after(err.response)
                 if signal is not None:
                     log_retry_after(self.logger, endpoint, signal)
                     raise SystemExit(err)
+                self.logger.error(err)
                 if retry < self.max_retries - 1:
                     time.sleep(2**retry)
                 else:

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -542,11 +542,11 @@ class PrefectMetrics(object):
                 resp.raise_for_status()
                 return CsrfToken.model_validate(resp.json())
             except requests.exceptions.RequestException as err:
-                self.logger.error(err)
                 signal = detect_retry_after(err.response)
                 if signal is not None:
                     log_retry_after(self.logger, endpoint, signal)
                     raise
+                self.logger.error(err)
                 if retry < self.max_retries - 1:
                     time.sleep(2**retry)
                 else:

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -9,6 +9,7 @@ from prometheus_client.core import GaugeMetricFamily
 from metrics.deployments import PrefectDeployments
 from metrics.flow_runs import PrefectFlowRuns
 from metrics.flows import PrefectFlows
+from metrics.retry_after import detect_retry_after, log_retry_after
 from metrics.work_pools import PrefectWorkPools
 from metrics.work_queues import PrefectWorkQueues
 
@@ -542,6 +543,10 @@ class PrefectMetrics(object):
                 return CsrfToken.model_validate(resp.json())
             except requests.exceptions.RequestException as err:
                 self.logger.error(err)
+                signal = detect_retry_after(err.response)
+                if signal is not None:
+                    log_retry_after(self.logger, endpoint, signal)
+                    raise
                 if retry < self.max_retries - 1:
                     time.sleep(2**retry)
                 else:

--- a/metrics/retry_after.py
+++ b/metrics/retry_after.py
@@ -1,11 +1,4 @@
-"""Helpers for honoring the HTTP Retry-After header.
-
-Prefect Cloud's maintenance mode returns 503 + ``Retry-After`` (typically
-1200s) along with ``Prefect-Maintenance: true``. The same header is also
-standard for 429 Too Many Requests. When we see this, we abort the current
-scrape rather than blocking the Prometheus scrape thread for minutes at a
-time. Prometheus will scrape again on its own cadence.
-"""
+"""Helpers for honoring the HTTP Retry-After header on 429/503 responses."""
 
 from __future__ import annotations
 
@@ -17,13 +10,13 @@ from typing import Optional
 import requests
 
 
+RETRY_AFTER_HEADER = "Retry-After"
+PREFECT_MAINTENANCE_HEADER = "Prefect-Maintenance"
 RETRY_AFTER_STATUSES = frozenset({429, 503})
 
 
 @dataclass(frozen=True)
 class RetryAfterSignal:
-    """A parsed Retry-After signal from a server response."""
-
     seconds: float
     status_code: int
     maintenance: bool
@@ -73,11 +66,11 @@ def detect_retry_after(
     if resp.status_code not in RETRY_AFTER_STATUSES:
         return None
 
-    seconds = parse_retry_after(resp.headers.get("Retry-After"))
+    seconds = parse_retry_after(resp.headers.get(RETRY_AFTER_HEADER))
     if seconds is None:
         return None
 
-    maintenance = resp.headers.get("Prefect-Maintenance", "").lower() == "true"
+    maintenance = resp.headers.get(PREFECT_MAINTENANCE_HEADER, "").lower() == "true"
     return RetryAfterSignal(
         seconds=seconds,
         status_code=resp.status_code,
@@ -86,7 +79,6 @@ def detect_retry_after(
 
 
 def log_retry_after(logger, endpoint: str, signal: RetryAfterSignal) -> None:
-    """Emit a consistent warning for a Retry-After signal."""
     kind = "maintenance mode" if signal.maintenance else "server-requested backoff"
     logger.warning(
         "Aborting scrape of %s: %s (status=%s, Retry-After=%.0fs)",

--- a/metrics/retry_after.py
+++ b/metrics/retry_after.py
@@ -1,0 +1,97 @@
+"""Helpers for honoring the HTTP Retry-After header.
+
+Prefect Cloud's maintenance mode returns 503 + ``Retry-After`` (typically
+1200s) along with ``Prefect-Maintenance: true``. The same header is also
+standard for 429 Too Many Requests. When we see this, we abort the current
+scrape rather than blocking the Prometheus scrape thread for minutes at a
+time. Prometheus will scrape again on its own cadence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+
+RETRY_AFTER_STATUSES = frozenset({429, 503})
+
+
+@dataclass(frozen=True)
+class RetryAfterSignal:
+    """A parsed Retry-After signal from a server response."""
+
+    seconds: float
+    status_code: int
+    maintenance: bool
+
+
+def parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse a Retry-After header value into seconds-from-now.
+
+    Accepts either delta-seconds or an HTTP-date per RFC 7231 section 7.1.3.
+    Returns ``None`` if the value is missing or unparseable. Negative
+    values clamp to 0.
+    """
+    if value is None:
+        return None
+
+    raw = value.strip()
+    if not raw:
+        return None
+
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        pass
+
+    try:
+        when = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    delta = (when - datetime.now(timezone.utc)).total_seconds()
+    return max(0.0, delta)
+
+
+def detect_retry_after(
+    resp: Optional[requests.Response],
+) -> Optional[RetryAfterSignal]:
+    """Return a RetryAfterSignal if ``resp`` is a 429/503 with Retry-After.
+
+    Returns ``None`` for any other response (including missing response,
+    unrelated status codes, or 429/503 without a usable Retry-After).
+    """
+    if resp is None:
+        return None
+    if resp.status_code not in RETRY_AFTER_STATUSES:
+        return None
+
+    seconds = parse_retry_after(resp.headers.get("Retry-After"))
+    if seconds is None:
+        return None
+
+    maintenance = resp.headers.get("Prefect-Maintenance", "").lower() == "true"
+    return RetryAfterSignal(
+        seconds=seconds,
+        status_code=resp.status_code,
+        maintenance=maintenance,
+    )
+
+
+def log_retry_after(logger, endpoint: str, signal: RetryAfterSignal) -> None:
+    """Emit a consistent warning for a Retry-After signal."""
+    kind = "maintenance mode" if signal.maintenance else "server-requested backoff"
+    logger.warning(
+        "Aborting scrape of %s: %s (status=%s, Retry-After=%.0fs)",
+        endpoint,
+        kind,
+        signal.status_code,
+        signal.seconds,
+    )

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -4,6 +4,7 @@ import requests
 import time
 
 from metrics.api_metric import PrefectApiMetric
+from metrics.retry_after import detect_retry_after, log_retry_after
 
 
 class PrefectWorkQueues(PrefectApiMetric):
@@ -80,6 +81,10 @@ class PrefectWorkQueues(PrefectApiMetric):
                 return resp.json()
             except requests.exceptions.RequestException as err:
                 self.logger.error(err)
+                signal = detect_retry_after(err.response)
+                if signal is not None:
+                    log_retry_after(self.logger, endpoint, signal)
+                    return {}
                 if retry < self.max_retries - 1:
                     time.sleep(2**retry)
                 else:

--- a/metrics/work_queues.py
+++ b/metrics/work_queues.py
@@ -80,11 +80,11 @@ class PrefectWorkQueues(PrefectApiMetric):
                 resp.raise_for_status()
                 return resp.json()
             except requests.exceptions.RequestException as err:
-                self.logger.error(err)
                 signal = detect_retry_after(err.response)
                 if signal is not None:
                     log_retry_after(self.logger, endpoint, signal)
                     return {}
+                self.logger.error(err)
                 if retry < self.max_retries - 1:
                     time.sleep(2**retry)
                 else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.3
+responses==0.25.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest config: ensure the repo root is importable so `from metrics...` works."""
+
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_api_metric.py
+++ b/tests/test_api_metric.py
@@ -1,0 +1,118 @@
+import logging
+from unittest.mock import MagicMock
+
+import responses
+
+from metrics.api_metric import PrefectApiMetric
+
+
+def _make(uri="deployments", **overrides):
+    kwargs = dict(
+        url="http://prefect.test/api",
+        headers={"accept": "application/json"},
+        max_retries=3,
+        logger=logging.getLogger("test"),
+        enable_pagination=True,
+        pagination_limit=2,
+        uri=uri,
+    )
+    kwargs.update(overrides)
+    return PrefectApiMetric(**kwargs)
+
+
+@responses.activate
+def test_maintenance_503_aborts_immediately(monkeypatch):
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.api_metric.time.sleep", sleep_mock)
+
+    responses.add(
+        responses.POST,
+        "http://prefect.test/api/deployments/filter",
+        status=503,
+        headers={"Retry-After": "1200", "Prefect-Maintenance": "true"},
+        json={"detail": "Prefect will retry this request shortly"},
+    )
+
+    api = _make()
+    result = api._get_with_pagination()
+
+    assert result == []
+    # No sleeps. No retries. One call.
+    assert sleep_mock.call_count == 0
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_partial_results_when_retry_after_hits_mid_pagination(monkeypatch):
+    monkeypatch.setattr("metrics.api_metric.time.sleep", MagicMock())
+
+    url = "http://prefect.test/api/deployments/filter"
+    responses.add(responses.POST, url, status=200, json=[{"id": "a"}, {"id": "b"}])
+    responses.add(
+        responses.POST,
+        url,
+        status=503,
+        headers={"Retry-After": "1200", "Prefect-Maintenance": "true"},
+        json={"detail": "maintenance"},
+    )
+
+    api = _make()
+    result = api._get_with_pagination()
+
+    assert result == [{"id": "a"}, {"id": "b"}]
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_429_with_retry_after_also_aborts(monkeypatch):
+    monkeypatch.setattr("metrics.api_metric.time.sleep", MagicMock())
+
+    responses.add(
+        responses.POST,
+        "http://prefect.test/api/deployments/filter",
+        status=429,
+        headers={"Retry-After": "5"},
+        json={"detail": "rate limited"},
+    )
+
+    api = _make()
+    result = api._get_with_pagination()
+
+    assert result == []
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_500_without_retry_after_still_retries(monkeypatch):
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.api_metric.time.sleep", sleep_mock)
+
+    url = "http://prefect.test/api/deployments/filter"
+    for _ in range(3):
+        responses.add(responses.POST, url, status=500, json={"err": "boom"})
+
+    api = _make(max_retries=3)
+    result = api._get_with_pagination()
+
+    assert result == []
+    # 3 attempts, 2 sleeps (between attempts 0->1 and 1->2).
+    assert len(responses.calls) == 3
+    assert sleep_mock.call_count == 2
+
+
+@responses.activate
+def test_503_without_retry_after_still_retries(monkeypatch):
+    """503 alone (no Retry-After header) should NOT trigger the abort path."""
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.api_metric.time.sleep", sleep_mock)
+
+    url = "http://prefect.test/api/deployments/filter"
+    for _ in range(3):
+        responses.add(responses.POST, url, status=503, json={})
+
+    api = _make(max_retries=3)
+    result = api._get_with_pagination()
+
+    assert result == []
+    assert len(responses.calls) == 3
+    assert sleep_mock.call_count == 2

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,51 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import responses
+
+from metrics.healthz import PrefectHealthz
+
+
+def _make():
+    return PrefectHealthz(
+        url="http://prefect.test/api",
+        headers={"accept": "application/json"},
+        max_retries=3,
+        logger=logging.getLogger("test"),
+    )
+
+
+@responses.activate
+def test_health_503_with_retry_after_exits_immediately(monkeypatch):
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.healthz.time.sleep", sleep_mock)
+
+    responses.add(
+        responses.GET,
+        "http://prefect.test/api/health",
+        status=503,
+        headers={"Retry-After": "1200", "Prefect-Maintenance": "true"},
+        json={},
+    )
+
+    with pytest.raises(SystemExit):
+        _make().get_health_check()
+
+    assert sleep_mock.call_count == 0
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_health_success(monkeypatch):
+    monkeypatch.setattr("metrics.healthz.time.sleep", MagicMock())
+
+    responses.add(
+        responses.GET,
+        "http://prefect.test/api/health",
+        status=200,
+        json={"ok": True},
+    )
+
+    _make().get_health_check()
+    assert len(responses.calls) == 1

--- a/tests/test_metrics_csrf.py
+++ b/tests/test_metrics_csrf.py
@@ -1,0 +1,45 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+import responses
+
+from metrics.metrics import PrefectMetrics
+
+
+def _make():
+    return PrefectMetrics(
+        url="http://prefect.test/api",
+        headers={"accept": "application/json"},
+        offset_minutes=3,
+        failed_runs_offset_minutes=10080,
+        failed_runs_limit=10,
+        max_retries=3,
+        client_id="test-client-id",
+        csrf_enabled=True,
+        logger=logging.getLogger("test"),
+        enable_pagination=False,
+        pagination_limit=200,
+        enable_flow_run_name_label=False,
+    )
+
+
+@responses.activate
+def test_csrf_503_with_retry_after_raises_immediately(monkeypatch):
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.metrics.time.sleep", sleep_mock)
+
+    responses.add(
+        responses.GET,
+        "http://prefect.test/api/csrf-token",
+        status=503,
+        headers={"Retry-After": "1200", "Prefect-Maintenance": "true"},
+        json={},
+    )
+
+    with pytest.raises(requests.exceptions.RequestException):
+        _make().get_csrf_token()
+
+    assert sleep_mock.call_count == 0
+    assert len(responses.calls) == 1

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from unittest.mock import MagicMock
+
+from metrics.retry_after import (
+    detect_retry_after,
+    log_retry_after,
+    parse_retry_after,
+)
+
+
+class TestParseRetryAfter:
+    def test_delta_seconds(self):
+        assert parse_retry_after("1200") == 1200.0
+
+    def test_delta_seconds_with_whitespace(self):
+        assert parse_retry_after("  30  ") == 30.0
+
+    def test_negative_clamps_to_zero(self):
+        assert parse_retry_after("-5") == 0.0
+
+    def test_none(self):
+        assert parse_retry_after(None) is None
+
+    def test_empty(self):
+        assert parse_retry_after("") is None
+        assert parse_retry_after("   ") is None
+
+    def test_garbage(self):
+        assert parse_retry_after("soon") is None
+
+    def test_http_date_future(self):
+        future = datetime.now(timezone.utc) + timedelta(seconds=60)
+        result = parse_retry_after(format_datetime(future, usegmt=True))
+        assert result is not None
+        assert 50 <= result <= 70
+
+    def test_http_date_past_clamps_to_zero(self):
+        past = datetime.now(timezone.utc) - timedelta(seconds=60)
+        result = parse_retry_after(format_datetime(past, usegmt=True))
+        assert result == 0.0
+
+
+def _resp(status: int, headers: dict | None = None) -> MagicMock:
+    m = MagicMock()
+    m.status_code = status
+    m.headers = headers or {}
+    return m
+
+
+class TestDetectRetryAfter:
+    def test_none_response(self):
+        assert detect_retry_after(None) is None
+
+    def test_503_with_retry_after(self):
+        signal = detect_retry_after(_resp(503, {"Retry-After": "1200"}))
+        assert signal is not None
+        assert signal.seconds == 1200.0
+        assert signal.status_code == 503
+        assert signal.maintenance is False
+
+    def test_503_with_maintenance_header(self):
+        signal = detect_retry_after(
+            _resp(
+                503,
+                {"Retry-After": "1200", "Prefect-Maintenance": "true"},
+            )
+        )
+        assert signal is not None
+        assert signal.maintenance is True
+
+    def test_maintenance_header_case_insensitive(self):
+        signal = detect_retry_after(
+            _resp(503, {"Retry-After": "1", "Prefect-Maintenance": "TRUE"})
+        )
+        assert signal is not None
+        assert signal.maintenance is True
+
+    def test_429_with_retry_after(self):
+        signal = detect_retry_after(_resp(429, {"Retry-After": "10"}))
+        assert signal is not None
+        assert signal.status_code == 429
+
+    def test_500_not_triggered(self):
+        assert detect_retry_after(_resp(500, {"Retry-After": "10"})) is None
+
+    def test_503_without_header_not_triggered(self):
+        assert detect_retry_after(_resp(503, {})) is None
+
+    def test_503_with_unparseable_header_not_triggered(self):
+        assert detect_retry_after(_resp(503, {"Retry-After": "soon"})) is None
+
+
+def test_log_retry_after_maintenance():
+    logger = MagicMock()
+    signal = detect_retry_after(
+        _resp(503, {"Retry-After": "1200", "Prefect-Maintenance": "true"})
+    )
+    assert signal is not None
+    log_retry_after(logger, "https://api/foo", signal)
+    args, _ = logger.warning.call_args
+    assert "maintenance mode" in args[0] % args[1:]
+    assert "https://api/foo" in args[0] % args[1:]
+
+
+def test_log_retry_after_generic():
+    logger = MagicMock()
+    signal = detect_retry_after(_resp(429, {"Retry-After": "10"}))
+    assert signal is not None
+    log_retry_after(logger, "https://api/foo", signal)
+    args, _ = logger.warning.call_args
+    rendered = args[0] % args[1:]
+    assert "server-requested backoff" in rendered

--- a/tests/test_work_queues.py
+++ b/tests/test_work_queues.py
@@ -1,0 +1,54 @@
+import logging
+import uuid
+from unittest.mock import MagicMock
+
+import responses
+
+from metrics.work_queues import PrefectWorkQueues
+
+
+def _make():
+    return PrefectWorkQueues(
+        url="http://prefect.test/api",
+        headers={"accept": "application/json"},
+        max_retries=3,
+        logger=logging.getLogger("test"),
+        enable_pagination=True,
+        pagination_limit=2,
+    )
+
+
+@responses.activate
+def test_status_503_with_retry_after_returns_empty(monkeypatch):
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.work_queues.time.sleep", sleep_mock)
+
+    queue_id = uuid.uuid4()
+    responses.add(
+        responses.GET,
+        f"http://prefect.test/api/work_queues/{queue_id}/status",
+        status=503,
+        headers={"Retry-After": "1200", "Prefect-Maintenance": "true"},
+        json={},
+    )
+
+    result = _make().get_work_queue_status_info(queue_id)
+    assert result == {}
+    assert sleep_mock.call_count == 0
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_status_500_without_retry_after_still_retries(monkeypatch):
+    sleep_mock = MagicMock()
+    monkeypatch.setattr("metrics.work_queues.time.sleep", sleep_mock)
+
+    queue_id = uuid.uuid4()
+    url = f"http://prefect.test/api/work_queues/{queue_id}/status"
+    for _ in range(3):
+        responses.add(responses.GET, url, status=500, json={})
+
+    result = _make().get_work_queue_status_info(queue_id)
+    assert result == {}
+    assert len(responses.calls) == 3
+    assert sleep_mock.call_count == 2


### PR DESCRIPTION
### Summary

Related to https://linear.app/prefect/issue/PLA-2682

Prefect Cloud's [maintenance mode](https://github.com/PrefectHQ/cluster-deployment/blob/main/cloud2/scripts/maintenance-mode.yaml) returns `503` with `Retry-After: 1200` and `Prefect-Maintenance: true`. The exporter currently ignores both headers and keeps retrying on its fixed exponential backoff, hammering the API during the window.

Now any `429`/`503` with a `Retry-After` header aborts the current scrape and returns partial/empty results. Prometheus re-scrapes on its own cadence. Generic 5xx without `Retry-After` still uses the existing backoff path, so transient errors behave as before.

Bail-rather-than-sleep was a deliberate choice. Sleeping for the full `Retry-After` (typically 20 min) would block the scrape thread and make `/metrics` hang for the duration of the window.

`Retry-After` parsing accepts both delta-seconds (what Prefect Cloud sends) and HTTP-date per RFC 7231. The `Prefect-Maintenance: true` header is detected and surfaced in the log line.

### Testing

Unit tests (28 of them, all passing) cover the helper plus each of the four patched call sites — maintenance path, 429 path, non-`Retry-After` 5xx still hitting the existing backoff, and partial-results mid-pagination. CI now runs `pytest` on every PR and push to `main`.

Validated end-to-end with `docker compose`:

1. **Baseline** — `docker compose up -d` (real Prefect server). Exporter started, health check passed, all five `prefect_*_total` metric families scraped cleanly.
2. **Maintenance simulation** — Ran an nginx container that mirrors the Prefect Cloud maintenance contract: `503` with `Retry-After: 1200` and `Prefect-Maintenance: true` on all `/api/*` paths except `/health`. Pointed a fresh exporter at it.

<details>
<summary>nginx config used for the maintenance simulation</summary>

```nginx
events {}
http {
  server {
    listen 80;
    # Let /health succeed so the exporter starts up.
    location = /api/health {
      add_header Content-Type "application/json" always;
      return 200 '{"status":"ok"}';
    }
    # Everything else: emulate Prefect Cloud maintenance.
    location / {
      add_header Content-Type "application/json" always;
      add_header Prefect-Maintenance "true" always;
      add_header Retry-After "1200" always;
      return 503 '{"detail":"Prefect will retry this request shortly"}';
    }
  }
}
```

Run it on the compose network so the exporter can reach it by name:

```bash
docker run -d --name maintenance-emulator \
  --network <compose-network> \
  -v $PWD/nginx.conf:/etc/nginx/nginx.conf:ro \
  nginx:alpine

docker run -d --name exporter-maint \
  --network <compose-network> \
  -e PREFECT_API_URL=http://maintenance-emulator/api \
  -e LOG_LEVEL=DEBUG \
  -e MAX_RETRIES=3 \
  -p 8001:8000 \
  <image-built-from-this-branch>
```

The `always` flag on `add_header` is the gotcha — nginx omits custom headers from non-2xx responses by default, which would have made this whole test a no-op.

</details>

Logs under simulated maintenance (one WARNING per endpoint, no ERROR, no retries):

```
[INFO] Prefect health check: 200 - OK
[WARNING] Aborting scrape of http://.../api/deployments/filter: maintenance mode (status=503, Retry-After=1200s)
[WARNING] Aborting scrape of http://.../api/flows/filter: maintenance mode (status=503, Retry-After=1200s)
[WARNING] Aborting scrape of http://.../api/flow_runs/filter: maintenance mode (status=503, Retry-After=1200s)
[WARNING] Aborting scrape of http://.../api/work_pools/filter: maintenance mode (status=503, Retry-After=1200s)
[WARNING] Aborting scrape of http://.../api/work_queues/filter: maintenance mode (status=503, Retry-After=1200s)
[INFO] Exporter listening on 0.0.0.0:8000
```

`/metrics` returned in **29 ms** under simulated maintenance with zero-valued samples (vs. the prior behavior, which would have blocked for ~21 s per failing endpoint walking the `1+2+4` backoff ladder).

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

Started from a question about whether the exporter respects `Retry-After` during Prefect maintenance windows. It does not, anywhere. Audited all four HTTP call sites (`api_metric`, `work_queues`, `metrics` CSRF, `healthz`) and patched them through a shared `metrics/retry_after.py` helper.

Considered three behaviors for `Retry-After`: sleep full duration, cap the sleep, or bail. Picked bail because a multi-minute `time.sleep` inside a Prometheus collector blocks the scrape thread and makes `/metrics` unresponsive — Prometheus scraping again on its own cadence is the better answer for an exporter.

Repo had no test suite; added pytest + `responses` and 28 tests covering the helper and each call site (maintenance path, 429 path, 5xx-without-Retry-After path still retries, partial-results mid-pagination).

</details>