### PR TITLE
fix(metrics): correct prefect_flow_runs_ongoing_run_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can modify environment variables to change the behavior of the exporter.
 | `PAGINATION_LIMIT` | Number of results to retrieve per request when pagination is enabled. Consider lowering this value for large instances to make more, but smaller, requests. | `200` |
 | `FAILED_RUNS_OFFSET_MINUTES` | Time window in minutes for the `prefect_deployment_failed_flow_runs` metric. Failed runs older than this window are ignored. Set to `0` to disable the metric entirely. | `10080` (7 days) |
 | `FAILED_RUNS_LIMIT` | Maximum number of recent failed runs to expose per deployment in `prefect_deployment_failed_flow_runs`. | `10` |
-| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs` and `prefect_flow_runs_ongoing_run_time`. Increases cardinality proportional to the number of concurrent flow runs within the `OFFSET_MINUTES` window, not total historical runs. Series go stale once runs fall outside the window. | `False` |
+| `ENABLE_FLOW_RUN_NAME_LABEL` | Add `flow_run_name` label to `prefect_info_flow_runs` and `prefect_flow_runs_ongoing_run_time`. Increases cardinality proportional to the number of concurrent flow runs within the `OFFSET_MINUTES` window, not total historical runs. Series go stale once runs fall outside the window. Note: `prefect_flow_runs_ongoing_run_time` always carries a `flow_run_id` label so each ongoing run is a distinct series (cardinality bounded by the number of concurrent ongoing runs, which is self-expiring). | `False` |
 
 ## Contributing
 

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -175,6 +175,10 @@ class PrefectMetrics(object):
             self.pagination_limit,
         ).get_work_queues_info()
 
+        # O(1) id -> name lookups reused across the flow-run metric loops below.
+        deployments_by_id = {d["id"]: d["name"] for d in deployments if d.get("id")}
+        flows_by_id = {f["id"]: f["name"] for f in flows if f.get("id")}
+
         ##
         # PREFECT DEPLOYMENTS METRICS
         #
@@ -329,10 +333,14 @@ class PrefectMetrics(object):
 
         yield prefect_flow_runs_total_run_time
 
+        # flow_run_id keeps each ongoing run a distinct timeseries. Without it,
+        # multiple runs of the same flow/deployment/state collapse to identical
+        # label tuples and Prometheus rejects the scrape as duplicate samples.
         prefect_flow_run_ongoing_labels = [
             "deployment_name",
             "flow_name",
             "state_name",
+            "flow_run_id",
         ]
 
         if self.enable_flow_run_name_label:
@@ -347,49 +355,50 @@ class PrefectMetrics(object):
         current_time = datetime.now(timezone.utc)
 
         for flow_run in ongoing_flow_runs:
-            if flow_run.get("deployment_id") is None:
-                deployment_name = "null"
-            else:
-                deployment_name = next(
-                    (
-                        deployment.get("name")
-                        for deployment in deployments
-                        if flow_run.get("deployment_id") == deployment.get("id")
-                    ),
-                    "null",
-                )
+            deployment_name = deployments_by_id.get(
+                flow_run.get("deployment_id"), "null"
+            )
+            flow_name = flows_by_id.get(flow_run.get("flow_id"), "null")
 
-            # get flow name
-            if flow_run.get("flow_id") is None:
-                flow_name = "null"
-            else:
-                flow_name = next(
-                    (
-                        flow.get("name")
-                        for flow in flows
-                        if flow.get("id") == flow_run.get("flow_id")
-                    ),
-                    "null",
+            # A run with no start_time (e.g. PENDING/SCHEDULED) has no meaningful
+            # ongoing duration; skip it rather than report a misleading 0.
+            raw_start_time = flow_run.get("start_time")
+            if not raw_start_time:
+                continue
+
+            # Guard the parse: a malformed timestamp must never propagate and
+            # blank the entire scrape via collect()'s broad except.
+            try:
+                start_time = datetime.fromisoformat(raw_start_time)
+            except (TypeError, ValueError):
+                self.logger.warning(
+                    "Skipping ongoing flow run %s: unparseable start_time %r",
+                    flow_run.get("id"),
+                    raw_start_time,
                 )
+                continue
+
+            # The API may omit the offset, yielding a naive datetime that cannot
+            # be subtracted from the tz-aware current_time. Assume UTC.
+            if start_time.tzinfo is None:
+                start_time = start_time.replace(tzinfo=timezone.utc)
+
+            # Clamp: future-dated runs (SCHEDULED) would otherwise emit a
+            # negative duration for a "run time in seconds" gauge.
+            run_time = max(0.0, (current_time - start_time).total_seconds())
 
             label_keys = [
                 str(deployment_name),
                 str(flow_name),
-                str(flow_run.get("state_name")),
+                str(flow_run.get("state_name", "null")),
+                str(flow_run.get("id", "null")),
             ]
             if self.enable_flow_run_name_label:
                 label_keys.append(str(flow_run.get("name", "null")))
 
-            start_time = (
-                datetime.fromisoformat(flow_run.get("start_time"))
-                if flow_run.get("start_time")
-                else current_time
-            )
-            run_time = current_time - start_time
-
             prefect_flow_runs_ongoing_run_time.add_metric(
                 label_keys,
-                run_time.total_seconds(),
+                run_time,
             )
 
         yield prefect_flow_runs_ongoing_run_time
@@ -460,9 +469,6 @@ class PrefectMetrics(object):
             "Last failed or crashed flow run ID per deployment within the FAILED_RUNS_OFFSET_MINUTES window",
             labels=["deployment_name", "flow_name", "last_failed_run_id", "state_name"],
         )
-
-        deployments_by_id = {d["id"]: d["name"] for d in deployments if d.get("id")}
-        flows_by_id = {f["id"]: f["name"] for f in flows if f.get("id")}
 
         for (deployment_id, flow_id, state_name), run_ids in failed_flow_runs.items():
             deployment_name = deployments_by_id.get(deployment_id, "null")

--- a/tests/test_metrics_ongoing.py
+++ b/tests/test_metrics_ongoing.py
@@ -1,0 +1,243 @@
+"""Tests for the prefect_flow_runs_ongoing_run_time metric.
+
+Covers the correctness fixes from PLA-2754:
+  1. No duplicate timeseries (flow_run_id uniquifies same flow/deployment/state).
+  2. A naive (tz-less) start_time does not blank the whole scrape.
+  3. Future-dated runs never emit a negative run_time.
+  4. A null start_time emits no series (no misleading 0).
+  5. A missing state_name renders as "null", not "None".
+  6. enable_flow_run_name_label adds flow_run_name alongside flow_run_id.
+"""
+
+import json
+import logging
+
+import responses
+
+from metrics.metrics import PrefectMetrics
+
+URL = "http://prefect.test/api"
+
+DEPLOYMENT_ID = "dep-1"
+FLOW_ID = "flow-1"
+
+
+def _make(enable_flow_run_name_label=False):
+    return PrefectMetrics(
+        url=URL,
+        headers={"accept": "application/json"},
+        offset_minutes=3,
+        # 0 disables the failed-runs fetch, so no extra endpoint to mock.
+        failed_runs_offset_minutes=0,
+        failed_runs_limit=10,
+        max_retries=3,
+        client_id="test-client-id",
+        csrf_enabled=False,
+        logger=logging.getLogger("test"),
+        enable_pagination=False,
+        pagination_limit=200,
+        enable_flow_run_name_label=enable_flow_run_name_label,
+    )
+
+
+def _register_endpoints(ongoing_runs):
+    """Mock every /filter endpoint collect() touches.
+
+    flow_runs/filter is hit three times with different bodies (recent, all,
+    ongoing); a callback routes by request body so only the ongoing query
+    returns the supplied runs.
+    """
+    responses.add(
+        responses.POST,
+        f"{URL}/deployments/filter",
+        json=[{"id": DEPLOYMENT_ID, "name": "my-deployment", "flow_id": FLOW_ID}],
+    )
+    responses.add(
+        responses.POST,
+        f"{URL}/flows/filter",
+        json=[{"id": FLOW_ID, "name": "my-flow"}],
+    )
+    responses.add(
+        responses.POST,
+        f"{URL}/work_pools/filter",
+        json=[],
+    )
+    responses.add(
+        responses.POST,
+        f"{URL}/work_queues/filter",
+        json=[],
+    )
+
+    def flow_runs_callback(request):
+        body = json.loads(request.body)
+        flow_runs_filter = body.get("flow_runs", {})
+        # The ongoing query is the only one filtering on a null end_time.
+        is_ongoing = "is_null_" in flow_runs_filter.get("end_time", {})
+        payload = ongoing_runs if is_ongoing else []
+        return (200, {}, json.dumps(payload))
+
+    responses.add_callback(
+        responses.POST,
+        f"{URL}/flow_runs/filter",
+        callback=flow_runs_callback,
+        content_type="application/json",
+    )
+
+
+def _ongoing_family(metrics):
+    """Return the prefect_flow_runs_ongoing_run_time family from collect()."""
+    for family in metrics.collect():
+        if family.name == "prefect_flow_runs_ongoing_run_time":
+            return family
+    raise AssertionError("prefect_flow_runs_ongoing_run_time not yielded")
+
+
+def _samples(family):
+    """List of (labels_dict, value) for a metric family."""
+    return [(dict(s.labels), s.value) for s in family.samples]
+
+
+@responses.activate
+def test_no_duplicate_timeseries():
+    """Two RUNNING runs of the same flow/deployment/state are distinct series."""
+    _register_endpoints(
+        [
+            {
+                "id": "run-a",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                "state_name": "Running",
+                "start_time": "2026-06-01T10:00:00+00:00",
+            },
+            {
+                "id": "run-b",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                "state_name": "Running",
+                "start_time": "2026-06-01T10:00:00+00:00",
+            },
+        ]
+    )
+
+    samples = _samples(_ongoing_family(_make()))
+
+    assert len(samples) == 2
+    run_ids = {labels["flow_run_id"] for labels, _ in samples}
+    assert run_ids == {"run-a", "run-b"}
+    # Label tuples must be unique so Prometheus accepts the scrape.
+    label_tuples = [tuple(sorted(labels.items())) for labels, _ in samples]
+    assert len(set(label_tuples)) == len(label_tuples)
+
+
+@responses.activate
+def test_naive_start_time_does_not_blank_scrape():
+    """A tz-naive start_time must not raise out of collect() and zero all metrics."""
+    _register_endpoints(
+        [
+            {
+                "id": "run-naive",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                "state_name": "Running",
+                # No tz offset: previously caused TypeError on subtraction.
+                "start_time": "2026-06-01T10:00:00",
+            }
+        ]
+    )
+
+    families = list(_make().collect())
+    names = {f.name for f in families}
+    # The scrape is not blanked: other metrics are still present.
+    assert "prefect_info_deployment" in names
+    assert "prefect_flow_runs_ongoing_run_time" in names
+
+    family = next(f for f in families if f.name == "prefect_flow_runs_ongoing_run_time")
+    samples = _samples(family)
+    assert len(samples) == 1
+    labels, value = samples[0]
+    assert labels["flow_run_id"] == "run-naive"
+    assert value >= 0
+
+
+@responses.activate
+def test_future_start_time_not_negative():
+    """A future-dated SCHEDULED run reports run_time clamped to >= 0."""
+    _register_endpoints(
+        [
+            {
+                "id": "run-future",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                "state_name": "Scheduled",
+                "start_time": "2099-01-01T00:00:00+00:00",
+            }
+        ]
+    )
+
+    samples = _samples(_ongoing_family(_make()))
+    assert len(samples) == 1
+    _, value = samples[0]
+    assert value == 0.0
+
+
+@responses.activate
+def test_null_start_time_skipped():
+    """A run with no start_time emits no series (instead of a misleading 0)."""
+    _register_endpoints(
+        [
+            {
+                "id": "run-pending",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                "state_name": "Pending",
+                "start_time": None,
+            }
+        ]
+    )
+
+    samples = _samples(_ongoing_family(_make()))
+    assert samples == []
+
+
+@responses.activate
+def test_missing_state_name_renders_null():
+    """A run missing state_name uses the string 'null', not 'None'."""
+    _register_endpoints(
+        [
+            {
+                "id": "run-nostate",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                # state_name omitted entirely
+                "start_time": "2026-06-01T10:00:00+00:00",
+            }
+        ]
+    )
+
+    samples = _samples(_ongoing_family(_make()))
+    assert len(samples) == 1
+    labels, _ = samples[0]
+    assert labels["state_name"] == "null"
+
+
+@responses.activate
+def test_flow_run_name_label_added():
+    """enable_flow_run_name_label adds flow_run_name alongside flow_run_id."""
+    _register_endpoints(
+        [
+            {
+                "id": "run-named",
+                "name": "ambitious-aardvark",
+                "deployment_id": DEPLOYMENT_ID,
+                "flow_id": FLOW_ID,
+                "state_name": "Running",
+                "start_time": "2026-06-01T10:00:00+00:00",
+            }
+        ]
+    )
+
+    samples = _samples(_ongoing_family(_make(enable_flow_run_name_label=True)))
+    assert len(samples) == 1
+    labels, _ = samples[0]
+    assert labels["flow_run_id"] == "run-named"
+    assert labels["flow_run_name"] == "ambitious-aardvark"


### PR DESCRIPTION
### Summary

Follow-up to #130, which added `prefect_flow_runs_ongoing_run_time`. A code review surfaced a few correctness issues:

- **Duplicate timeseries.** Multiple ongoing runs of the same flow/deployment/state produced identical label tuples, so Prometheus rejected the scrape as duplicate samples. Now each ongoing run carries a permanent `flow_run_id` label and is its own series.
- **Naive timestamp blanked the whole scrape.** A `start_time` returned without a tz offset raised a `TypeError` on subtraction, which `collect()`'s broad `except` swallowed, silently dropping every metric. The parse is now guarded and naive values are assumed UTC.
- **Negative durations.** Future-dated SCHEDULED runs reported a negative `run_time`; now clamped to `>= 0`.
- **Misleading 0.** Runs with no `start_time` reported `0` ongoing seconds; they're now skipped instead.
- **`state_name` rendering.** A missing `state_name` rendered as the string `"None"`; now defaults to `"null"` like the other flow-run metrics.
- Reuses the existing `deployments_by_id`/`flows_by_id` lookups instead of a third O(n) scan.

Kept the dedicated ongoing-runs API call: its server-side filter (`end_time` null + state in RUNNING/PENDING/SCHEDULED) isn't derivable from the other fetches without changing semantics.

Added `tests/test_metrics_ongoing.py` covering each case (the first test of `collect()`'s metric output). Full suite: 34 passed under Python 3.11.

Related to PLA-2754

### Local validation (Docker Compose)

Brought up `prefect` + the exporter built from this branch, plus `prometheus`, via `docker compose up -d --build`. Then reproduced the headline failure mode against the live exporter:

1. Created two RUNNING flow runs of the **same** flow with no deployment — pre-fix these collapse to the identical label tuple `(deployment_name="null", flow_name="dup-test-flow", state_name="Running")`.
2. Scraped `localhost:8000/metrics`. Both runs emit as distinct series, separated by `flow_run_id`:

   ```
   prefect_flow_runs_ongoing_run_time{deployment_name="null",flow_name="dup-test-flow",flow_run_id="84d4b88c-...",state_name="Running"} 12.42
   prefect_flow_runs_ongoing_run_time{deployment_name="null",flow_name="dup-test-flow",flow_run_id="6778b5e3-...",state_name="Running"} 12.38
   ```

3. Confirmed Prometheus actually ingests them: target `prometheus-exporter:8000/metrics` is `up` with an empty `lastError`, and `prefect_flow_runs_ongoing_run_time` returns 3 distinct series. Pre-fix the duplicate tuple would have been rejected as a duplicate sample.
4. A SCHEDULED run (which this Prefect version leaves with `start_time=null`) emits **no** series, confirming the null-start_time skip rather than a misleading `0`.
5. Exporter logs show no errors or "skipping this scrape" lines across the run.

The naive-timestamp and negative-clamp paths can't be forced through this Prefect API (it returns tz-aware times and only sets `start_time` on the RUNNING transition), so those two stay covered by the unit tests in `tests/test_metrics_ongoing.py`.

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes related issue
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose
- [x] `Draft` status is used until ready for review

<details>
<summary>Session context</summary>

Started from the PLA-2754 code-review writeup on #130. Drove the fix test-first: wrote six failing cases against `collect()` output, then rewrote the ongoing-run loop. The duplicate-series fix went with a `flow_run_id` label (over aggregating) to preserve per-run duration, which is the gauge's intent. Mocking `flow_runs/filter` needed a body-routing callback since `collect()` hits that endpoint three times with different queries.
</details>
