### PR TITLE
PLA-2800: migrate helm-chart-release.yaml to prefect-ci-bot-public

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -13,10 +13,19 @@ jobs:
   create_helm_release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate prefect-ci-bot-public token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+          owner: PrefectHQ
+          repositories: prefect-helm
+
       - name: Create prefect-helm release
         run: |
           gh workflow run prometheus-exporter-helm-release.yaml \
             --repo PrefectHQ/prefect-helm \
             --ref main
         env:
-          GH_TOKEN: ${{ secrets.PREFECT_HELM_ACTIONS_RW }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
## Summary

Replaces `secrets.PREFECT_HELM_ACTIONS_RW` (PAT) with a short-lived installation token minted by the `prefect-ci-bot-public` GitHub App, scoped to `prefect-helm`. 

Resolves PLA-2800.

## Test plan

- [ ] After merge, cut the next release on this repo and verify the trigger to \`prefect-helm\` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)