### PR TITLE
PLA-2800: scope bridge App token to actions-only

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -21,6 +21,8 @@ jobs:
           private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
           owner: PrefectHQ
           repositories: prefect-helm
+          # Scope to the minimum needed for `gh workflow run`.
+          permission-actions: write
 
       - name: Create prefect-helm release
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #138. Scopes the `prefect-ci-bot-public` App token minted in `helm-chart-release.yaml` down to `actions:write` only. Without an explicit `permission-*` input, `actions/create-github-app-token@v3` issues a token that inherits the full App installation permission set on the target repo. The workflow only does `gh workflow run` against `prefect-helm`, so `actions:write` is sufficient.

This is the same scope-down pattern being applied to `prefect#22288` (the equivalent prefect-repo helm and docker-images workflows).

## Public-repo considerations

`prometheus-prefect-exporter` is a public OSS repo. The threat model:

- The workflow triggers only on `release`, so the App credentials are never exposed to fork-PR code execution.
- Token lifetime is already a 1-hour installation token (not the 180-day PAT it replaced).
- This change further narrows the minted token to actions-only, so a leak via a third-party action or supply-chain compromise cannot also push commits or open PRs in `prefect-helm`.

## Test plan

- [ ] After merge, monitor next `helm-chart-release.yaml` run on a `prefect-helm` release event to verify the actions-scoped token still successfully triggers `prometheus-exporter-helm-release.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)