### PR TITLE
fix(codeowners): use hyphenated team slugs (cloud-*)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PrefectHQ/cloud_platform
+* @PrefectHQ/cloud-platform


### PR DESCRIPTION
### Summary

Follow-up to the previous CODEOWNERS PR. It used `@PrefectHQ/cloud_platform` / `@PrefectHQ/cloud_backend` (underscores), but the actual GitHub **team slug** is derived from the team name (Cloud Platform → `cloud-platform`), so those were unknown owners and GitHub flagged the CODEOWNERS file with errors.

This switches `cloud_*` → `cloud-*` to match the real slugs.

Related to https://linear.app/prefect/issue/ENGPAR-72/revisit-github-engineering-teams