### PR TITLE
fix: query flow runs per state to avoid truncating FAILED/CRASHED

### DIFF
--- a/metrics/flow_runs.py
+++ b/metrics/flow_runs.py
@@ -9,6 +9,23 @@ class PrefectFlowRuns(PrefectApiMetric):
     PrefectFlowRuns class for interacting with Prefect's flow runs endpoints.
     """
 
+    # All terminal/non-terminal state types Prefect can report. get_flow_runs_info()
+    # queries each group separately so a high-volume state (e.g. COMPLETED) cannot crowd
+    # rarer states (FAILED/CRASHED) out of a limited/paginated result window.
+    # See https://github.com/PrefectHQ/prometheus-prefect-exporter/issues/113 and the
+    # upstream diagnosis in https://github.com/PrefectHQ/prefect/issues/20341.
+    STATE_TYPES = [
+        "SCHEDULED",
+        "PENDING",
+        "RUNNING",
+        "PAUSED",
+        "CANCELLING",
+        "CANCELLED",
+        "COMPLETED",
+        "FAILED",
+        "CRASHED",
+    ]
+
     def __init__(
         self,
         url,
@@ -50,20 +67,33 @@ class PrefectFlowRuns(PrefectApiMetric):
         """
         Get information about flow runs within a specified time range.
 
+        Queries each state type separately and merges the results. A single
+        unfiltered query is sorted by start_time and capped by the page/pagination
+        limit, so the most numerous state (typically COMPLETED) can push rarer
+        FAILED/CRASHED runs out of the returned window, under-counting them in
+        ``prefect_info_flow_runs``. Splitting per state bounds each query by that
+        state's own volume, so no state is silently truncated.
+
         Returns:
-            dict: JSON response containing flow runs information.
+            list: Flow runs across all state types, de-duplicated by run id.
 
         """
-        flow_runs = self._get_with_pagination(
-            base_data={
-                "flow_runs": {
-                    "operator": "and_",
-                    "start_time": {"after_": f"{self.after_data_fmt}"},
+        flow_runs_by_id = {}
+        for state_type in self.STATE_TYPES:
+            for flow_run in self._get_with_pagination(
+                base_data={
+                    "flow_runs": {
+                        "operator": "and_",
+                        "start_time": {"after_": f"{self.after_data_fmt}"},
+                        "state": {"type": {"any_": [state_type]}},
+                    }
                 }
-            }
-        )
+            ):
+                # A run can only hold one state, but de-dupe by id defensively so a
+                # run observed transitioning between queries is never double-counted.
+                flow_runs_by_id[flow_run.get("id")] = flow_run
 
-        return flow_runs
+        return list(flow_runs_by_id.values())
 
     def get_all_flow_runs_info(self) -> list:
         """

--- a/tests/test_flow_runs.py
+++ b/tests/test_flow_runs.py
@@ -1,0 +1,146 @@
+"""Tests for PrefectFlowRuns.get_flow_runs_info().
+
+Covers the fix for issue #113: a single unfiltered flow-runs query is capped by
+the page/pagination limit and sorted by start_time, so a high-volume state
+(COMPLETED) can crowd FAILED/CRASHED runs out of the returned window. The method
+now queries each state type separately and merges the results, so no state is
+silently truncated.
+"""
+
+import json
+import logging
+
+import responses
+
+from metrics.flow_runs import PrefectFlowRuns
+
+URL = "http://prefect.test/api"
+
+
+def _make(enable_pagination=False, pagination_limit=200):
+    return PrefectFlowRuns(
+        url=URL,
+        headers={"accept": "application/json"},
+        max_retries=3,
+        offset_minutes=3,
+        logger=logging.getLogger("test"),
+        enable_pagination=enable_pagination,
+        pagination_limit=pagination_limit,
+    )
+
+
+def _register_by_state(runs_by_state):
+    """Route flow_runs/filter by the single state type in the request body.
+
+    Mirrors how the real API would answer a state-filtered query: each query
+    sees only its own state's runs, so it is bounded by that state's volume and
+    never truncated by the more numerous COMPLETED runs.
+    """
+
+    def callback(request):
+        body = json.loads(request.body)
+        state_filter = body["flow_runs"]["state"]["type"]["any_"]
+        # get_flow_runs_info queries one state type at a time.
+        state_type = state_filter[0]
+        limit = body.get("limit")
+        offset = body.get("offset", 0)
+        runs = runs_by_state.get(state_type, [])
+        page = runs[offset : offset + limit] if limit is not None else runs
+        return (200, {}, json.dumps(page))
+
+    responses.add_callback(
+        responses.POST,
+        f"{URL}/flow_runs/filter",
+        callback=callback,
+        content_type="application/json",
+    )
+
+
+def _run(run_id, state_type):
+    return {
+        "id": run_id,
+        "deployment_id": "dep-1",
+        "flow_id": "flow-1",
+        "state_name": state_type.capitalize(),
+        "start_time": "2026-06-01T10:00:00+00:00",
+    }
+
+
+@responses.activate
+def test_failed_runs_not_crowded_out_by_completed():
+    """FAILED/CRASHED runs are returned even when COMPLETED alone exceeds the limit.
+
+    With a single unfiltered query (limit 200) and 200 COMPLETED runs sorted
+    first, the FAILED/CRASHED runs would never appear. Per-state querying
+    surfaces them regardless.
+    """
+    runs_by_state = {
+        "COMPLETED": [_run(f"done-{i}", "COMPLETED") for i in range(200)],
+        "FAILED": [_run("fail-1", "FAILED"), _run("fail-2", "FAILED")],
+        "CRASHED": [_run("crash-1", "CRASHED")],
+    }
+    _register_by_state(runs_by_state)
+
+    result = _make(enable_pagination=False, pagination_limit=200).get_flow_runs_info()
+
+    ids = {r["id"] for r in result}
+    assert "fail-1" in ids
+    assert "fail-2" in ids
+    assert "crash-1" in ids
+    # All completed runs are still present too.
+    assert len([r for r in result if r["id"].startswith("done-")]) == 200
+
+
+@responses.activate
+def test_queries_every_state_type():
+    """One query is issued per state type, covering all of them."""
+    _register_by_state({})
+    _make().get_flow_runs_info()
+
+    queried_states = []
+    for call in responses.calls:
+        body = json.loads(call.request.body)
+        queried_states.extend(body["flow_runs"]["state"]["type"]["any_"])
+
+    assert set(queried_states) == set(PrefectFlowRuns.STATE_TYPES)
+
+
+@responses.activate
+def test_results_deduplicated_by_id():
+    """A run id observed in two state queries is counted once."""
+    shared = _run("shared", "RUNNING")
+    runs_by_state = {
+        "RUNNING": [shared],
+        # Same id reappears under COMPLETED (e.g. it transitioned mid-scrape).
+        "COMPLETED": [dict(shared, state_name="Completed")],
+    }
+    _register_by_state(runs_by_state)
+
+    result = _make().get_flow_runs_info()
+
+    assert [r["id"] for r in result].count("shared") == 1
+
+
+@responses.activate
+def test_carries_start_time_filter():
+    """Each per-state query still constrains by the start_time window."""
+    _register_by_state({})
+    _make().get_flow_runs_info()
+
+    for call in responses.calls:
+        body = json.loads(call.request.body)
+        assert "after_" in body["flow_runs"]["start_time"]
+
+
+@responses.activate
+def test_pagination_applies_per_state():
+    """With pagination on, each state is fully paged, not capped at one page."""
+    runs_by_state = {
+        "FAILED": [_run(f"fail-{i}", "FAILED") for i in range(5)],
+    }
+    _register_by_state(runs_by_state)
+
+    result = _make(enable_pagination=True, pagination_limit=2).get_flow_runs_info()
+
+    failed_ids = {r["id"] for r in result if r["id"].startswith("fail-")}
+    assert len(failed_ids) == 5


### PR DESCRIPTION
### Summary

Fixes incomplete CRASHED/FAILED counts in `prefect_info_flow_runs` (issue #113).

`get_flow_runs_info()` issued a single unfiltered flow-runs query sorted by
`start_time` and capped by the page/pagination limit. When the most numerous
state (typically `COMPLETED`) exceeds that limit, rarer `FAILED`/`CRASHED` runs
fall outside the returned window and are under-counted.

This is the same root cause the Prefect OSS team identified upstream in
[prefect#20341](https://github.com/PrefectHQ/prefect/issues/20341): not a
`start_time` column bug, but a limit/sort truncation effect. Swapping to
`expected_start_time` (the original approach in #114) does not change which runs
get truncated, which is why @sticreations noted that one-liner was insufficient.

### What changed

Query **each state type separately** and merge the results (de-duplicated by run
`id`). Each query is then bounded by that state's own volume, so no state can be
crowded out of the window. This implements the state-split approach discussed on
#114.

The dedicated `prefect_deployment_failed_flow_runs` metric already filtered by
state (`["FAILED", "CRASHED"]`) and was therefore unaffected; the return shape of
`get_flow_runs_info()` is unchanged, so its consumer needs no changes.

### Tests

Adds `tests/test_flow_runs.py`:
- FAILED/CRASHED runs surface even when COMPLETED alone exceeds the limit
- a query is issued for every state type
- results are de-duplicated by id
- the `start_time` window filter is still applied per query
- pagination is applied per state

All 39 tests pass.

Supersedes #114. Thanks @sticreations for the original report and PR.

Closes #113

### Validation (Docker Compose)

Validated end-to-end with the repo's `compose.yml` (Prefect server + the exporter
built from this branch), forcing the truncation condition from #113 via
`PAGINATION_ENABLED=False`, `PAGINATION_LIMIT=5`, `OFFSET_MINUTES=60`.

Seeded 25 runs of one flow: **3 Failed + 2 Crashed (older)**, then **20 Completed
(newer)**, so a `START_TIME_DESC` limit-5 window is entirely Completed and crowds
the failures out. A raw limit-5 query against Prefect confirmed the bug
reproduces (returns only `{Completed: 5}`).

A/B of the exporter's `/metrics`, old code (`main`) vs. this branch:

| state    | OLD (`main`)   | NEW (this branch) | actual |
|----------|----------------|-------------------|--------|
| Completed | 4.0           | 5.0               | 20     |
| **Failed**  | **missing** ❌ | **3.0** ✅        | 3      |
| **Crashed** | 1.0 (partial) ❌ | **2.0** ✅      | 2      |

The old build dropped Failed entirely and under-counted Crashed; the fixed build
reports the complete count for every rare state. (Completed shows 5 = its own
per-state limit, the intended bound, not the bug.)

### Requirements

- [x] [Contributing guide](https://github.com/PrefectHQ/prefect-helm/?tab=readme-ov-file#contributing) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels are added
- [x] Changes have been validated by running the provider using Docker Compose


